### PR TITLE
Support Kubernetes cluster autoscaling

### DIFF
--- a/kubernetes/cluster-autoscaler/deployment.yaml
+++ b/kubernetes/cluster-autoscaler/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        k8s-app: cluster-autoscaler
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: 'true'
+    spec:
+        containers:
+          - name: cluster-autoscaler
+            image: gcr.io/google_containers/cluster-autoscaler:v0.6.0
+            resources:
+              limits:
+                cpu: 100m
+                memory: 300Mi
+              requests:
+                cpu: 100m
+                memory: 300Mi
+            command:
+              - ./cluster-autoscaler
+              - --cloud-provider=aws
+              - --skip-nodes-with-system-pods=false
+              - --skip-nodes-with-local-storage=false
+              - --nodes=2:5:nodes.k8s.operationcode.org
+            env:
+              - name: AWS_REGION
+                value: us-east-2
+            volumeMounts:
+              - name: ssl-certs
+                mountPath: "/etc/ssl/certs/ca-certificates.crt"
+                readOnly: true
+        volumes:
+          - name: ssl-certs
+            hostPath:
+              path: "/etc/ssl/certs/ca-certificates.crt"
+        nodeSelector:
+          kubernetes.io/role: master
+        tolerations: 
+          - key: "node-role.kubernetes.io/master"
+            operator: "Exists"
+            effect: "NoSchedule"


### PR DESCRIPTION
Cluster autoscaling will allow some dynamic expansion under traffic, if we also configure horizontal pod autoscalers.