### PR TITLE
Change application services to internal only

### DIFF
--- a/kubernetes/operationcode_backend/service.yml
+++ b/kubernetes/operationcode_backend/service.yml
@@ -2,10 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: operationcode-backend-service
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:633607774026:certificate/acf36f86-ba7c-4052-9a8a-09da24bbd597
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
 spec:
   selector:
     app: operationcode-backend
@@ -14,8 +10,4 @@ spec:
       name: http
       port: 80
       targetPort: 3000
-    - protocol: TCP
-      name: https
-      port: 443
-      targetPort: 3000
-  type: LoadBalancer
+  type: ClusterIP

--- a/kubernetes/operationcode_frontend/service.yml
+++ b/kubernetes/operationcode_frontend/service.yml
@@ -2,10 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: operationcode-frontend-service
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:633607774026:certificate/acf36f86-ba7c-4052-9a8a-09da24bbd597
-    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
 spec:
   selector:
     app: operationcode-frontend
@@ -14,8 +10,4 @@ spec:
       name: http
       port: 80
       targetPort: 4000
-    - protocol: TCP
-      name: https
-      port: 443
-      targetPort: 4000
-  type: LoadBalancer
+  type: ClusterIP


### PR DESCRIPTION
Kubernetes services of type `LoadBalancer` become costly with multiple services and multiple environments, as well as requiring all sorts of DNS adjustments.

Changing them to internal only in preparation for a unified Ingress.