### PR TITLE
Update backend deployment to use Kubernetes service names

### DIFF
--- a/kubernetes/operationcode_backend/deployment.yml
+++ b/kubernetes/operationcode_backend/deployment.yml
@@ -33,9 +33,9 @@ spec:
               name: backend-secrets
               key: forest_env_secret
         - name: POSTGRES_HOST
-          value: prod-postgres-20180107.czwauqf3tjaz.us-east-2.rds.amazonaws.com
+          value: opcode-postgres
         - name: REDIS_URL
-          value: redis://operationcode-redis-redis:6379/0
+          value: redis://opcode-redis:6379/0
         - name: RAILS_ENV
           value: production
         - name: SLACK_SUBDOMAIN
@@ -77,9 +77,9 @@ spec:
               name: backend-secrets
               key: postgres_password
         - name: POSTGRES_HOST
-          value: operationcode-staging-psql-postgresql
+          value: opcode-postgres
         - name: REDIS_URL
-          value: redis://operationcode-redis-redis:6379/0
+          value: redis://opcode-redis:6379/0
         - name: SLACK_SUBDOMAIN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This change depends on @johnharris85's changeset for `opcode-redis` and `opcode-postgres` services.

The intent is to render both production and staging environment deployments identical, while the services the deployments reference will point to different locations in their own namespaces.