### PR TITLE
Environment variables added for slack invites and staging. 

### DIFF
--- a/kubernetes/operationcode_backend/deployment.yml
+++ b/kubernetes/operationcode_backend/deployment.yml
@@ -78,11 +78,6 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: slack_subdomain
-        - name: SLACK_LEGACY_ADMIN_TOKEN 
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_legacy_admin_token 
         - name: SLACK_TOKEN
           valueFrom:
             secretKeyRef:
@@ -130,6 +125,11 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: slack_subdomain
+        - name: SLACK_LEGACY_ADMIN_TOKEN 
+          valueFrom:
+            secretKeyRef:
+              name: backend-secrets
+              key: slack_legacy_admin_token 
         - name: SLACK_TOKEN
           valueFrom:
             secretKeyRef:

--- a/kubernetes/operationcode_backend/deployment.yml
+++ b/kubernetes/operationcode_backend/deployment.yml
@@ -78,6 +78,11 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: slack_subdomain
+        - name: SLACK_LEGACY_ADMIN_TOKEN 
+          valueFrom:
+            secretKeyRef:
+              name: backend-secrets
+              key: slack_legacy_admin_token 
         - name: SLACK_TOKEN
           valueFrom:
             secretKeyRef:
@@ -111,6 +116,11 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: postgres_password
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: backend-secrets
+              key: postgres_user
         - name: POSTGRES_HOST
           value: opcode-postgres
         - name: REDIS_URL

--- a/kubernetes/operationcode_backend/deployment.yml
+++ b/kubernetes/operationcode_backend/deployment.yml
@@ -37,26 +37,31 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: airtable_base_id
+              optional: true
         - name: GIT_HUB_CLIENT_ID
           valueFrom:
             secretKeyRef:
               name: backend-secrets
               key: git_hub_client_id
+              optional: true
         - name: GIT_HUB_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: backend-secrets
               key: git_hub_client_secret
+              optional: true
         - name: GIT_HUB_OAUTH_TOKEN
           valueFrom:
             secretKeyRef:
               name: backend-secrets
               key: git_hub_oauth_token
+              optional: true
         - name: PY_BOT_AUTH_KEY
           valueFrom:
             secretKeyRef:
               name: backend-secrets
               key: py_bot_auth_key
+              optional: true
         - name: POSTGRES_HOST
           value: opcode-postgres
         - name: REDIS_URL

--- a/kubernetes/operationcode_backend/deployment.yml
+++ b/kubernetes/operationcode_backend/deployment.yml
@@ -58,6 +58,11 @@ spec:
           value: redis://opcode-redis:6379/0
         - name: RAILS_ENV
           value: production
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: backend-secrets
+              key: postgres_user
         - name: SLACK_SUBDOMAIN
           valueFrom:
             secretKeyRef:

--- a/kubernetes/operationcode_backend/deployment.yml
+++ b/kubernetes/operationcode_backend/deployment.yml
@@ -27,6 +27,11 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: airtable_api_key
+        - name: SLACK_LEGACY_ADMIN_TOKEN 
+          valueFrom:
+            secretKeyRef:
+              name: backend-secrets
+              key: slack_legacy_admin_token 
         - name: AIRTABLE_BASE_ID
           valueFrom:
             secretKeyRef:

--- a/kubernetes/operationcode_backend/secrets/secret.yml.tpl
+++ b/kubernetes/operationcode_backend/secrets/secret.yml.tpl
@@ -5,6 +5,7 @@ metadata:
 type: Opaque
 data:
   airtable_add_user_base_id: SECRET
+  airtable_base_id: SECRET
   airtable_add_user_table_name: SECRET
   airtable_api_key: SECRET
   jwt_secret_key: SECRET

--- a/kubernetes/operationcode_backend/secrets/secret.yml.tpl
+++ b/kubernetes/operationcode_backend/secrets/secret.yml.tpl
@@ -11,6 +11,7 @@ data:
   postgres_password: SECRET
   postgres_user: SECRET
   secret_key_base: SECRET
+  slack_legacy_admin_token: SECRET
   sendgrid_password: SECRET
   sendgrid_username: SECRET
   sendgrid_api_key: SECRET

--- a/kubernetes/operationcode_backend/secrets/secret.yml.tpl
+++ b/kubernetes/operationcode_backend/secrets/secret.yml.tpl
@@ -9,6 +9,7 @@ data:
   airtable_api_key: SECRET
   jwt_secret_key: SECRET
   postgres_password: SECRET
+  postgres_user: SECRET
   secret_key_base: SECRET
   sendgrid_password: SECRET
   sendgrid_username: SECRET


### PR DESCRIPTION
https://github.com/OperationCode/operationcode_backend/pull/458

Already have POSTGRES_PASSWORD, adding `POSTGRES_USER` to the deployment file. 

This PR was work on the environment variables that affected 2 systems:
1. Allow optional prod only environment variables to fix staging systems
2. Set a slack token with a value we knew indicated it was an admin scope and not a normal application scope. 

These changes were related to getting the slack invites working, by moving the credentials into the kubernetes and by specifying which environment variables are optional for kubernetes in staging. Without these values in staging, kubernetes ran into errors where it'd look for them.

https://github.com/OperationCode/operationcode_backend/pull/447/files

These changes have been pushed to prod kubenernetes since Nov 9th in order to unblock @kylemh 





