### PR TITLE
Add DNS record for Grafana

### DIFF
--- a/dns/operationcode.org/records.tf
+++ b/dns/operationcode.org/records.tf
@@ -11,3 +11,10 @@ resource "dnsimple_record" "staging_api" {
   type = "CNAME"
   value = "${var.k8s-cluster-ingress}"
 }
+
+resource "dnsimple_record" "dashboards" {
+  domain = "${var.hosted-zone}"
+  name = "dashboards"
+  type = "CNAME"
+  value = "${var.k8s-cluster-ingress}"
+}


### PR DESCRIPTION
Allow public access to Grafana via dashboards.operationcode.org