### PR TITLE
fix run command

### DIFF
--- a/kubernetes/operationcode_backend/base/deployment.yaml
+++ b/kubernetes/operationcode_backend/base/deployment.yaml
@@ -112,7 +112,7 @@ spec:
               name: backend-secrets   
       - name: sidekiq
         image: operationcode/operationcode_backend:latest
-        command: ["sidekiq", "-C config/sidekiq.yml.erb"]
+        command: ["bundle", "exec", sidekiq", "-C config/sidekiq.yml.erb"]
         imagePullPolicy: Always
         env:
         - name: POSTGRES_PASSWORD

--- a/kubernetes/operationcode_backend/base/deployment.yaml
+++ b/kubernetes/operationcode_backend/base/deployment.yaml
@@ -112,7 +112,7 @@ spec:
               name: backend-secrets   
       - name: sidekiq
         image: operationcode/operationcode_backend:latest
-        command: ["bundle", "exec", sidekiq", "-C config/sidekiq.yml.erb"]
+        command: ["bundle", "exec", "sidekiq"]
         imagePullPolicy: Always
         env:
         - name: POSTGRES_PASSWORD


### PR DESCRIPTION
Need to run bundle exec prior due to changes in how the BE runs now. Additionally the cfg doesn't exist. Unsure if we need to specify or add a config so removing for now.

This change is only required when we merge the rails upgrade. I don't know what will happen with the current version. We could try pushing this and then manually changing the image to the one that was broken last night. Then merging the reverted PR. 