### PR TITLE
Rename resource secrets to match the actual secrets store

### DIFF
--- a/kubernetes/resources_api/base/deployment.yaml
+++ b/kubernetes/resources_api/base/deployment.yaml
@@ -17,16 +17,16 @@ spec:
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: resources-secrets
+              name: resources-api-secrets
               key: postgres_user
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: resources-secrets
+              name: resources-api-secrets
               key: postgres_password
         - name: POSTGRES_DB
           value: resources-psql
       volumes:
-      - name: resources-secrets
+      - name: resources-api-secrets
         secret:
-          secretName: resources-secrets
+          secretName: resources-api-secrets


### PR DESCRIPTION
The actual secrets store is called `resources-api-secrets` but the deployment.yaml file had `resources-secrets`. This fixes that so we can actually use the API.