### PR TITLE
Point the staging db service to the correct db

### DIFF
--- a/kubernetes/resources_api/overlays/staging/database-service.yaml
+++ b/kubernetes/resources_api/overlays/staging/database-service.yaml
@@ -1,7 +1,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: opcode-postgres
+  name: resources-postgres
 spec:
   type: ExternalName
   externalName: resources-api-20190427.czwauqf3tjaz.us-east-2.rds.amazonaws.com


### PR DESCRIPTION
This fixes a copy-paste fail where the resources staging database is pointing at the DB for the OC backend instead of the resources db.