### PR TITLE
Fix the command that the container starts with

### DIFF
--- a/kubernetes/resources_api/base/deployment.yaml
+++ b/kubernetes/resources_api/base/deployment.yaml
@@ -10,9 +10,11 @@ spec:
       containers:
       - name: app
         image: operationcode/resources-api:latest
+        command: ["flask"]
+        args: ["run", "-h", "0.0.0.0"]
         imagePullPolicy: Always
         ports:
-        - containerPort: 8000
+        - containerPort: 5000
         env:
         - name: POSTGRES_USER
           valueFrom:
@@ -25,9 +27,9 @@ spec:
               name: resources-api-secrets
               key: postgres_password
         - name: POSTGRES_DB
-          value: resources_api 
+          value: resources_api
         - name: POSTGRES_HOST
-          value: resources-postgres 
+          value: resources-postgres
       volumes:
       - name: resources-api-secrets
         secret:

--- a/kubernetes/resources_api/base/service.yaml
+++ b/kubernetes/resources_api/base/service.yaml
@@ -9,5 +9,5 @@ spec:
     - protocol: TCP
       name: http
       port: 80
-      targetPort: 8000
+      targetPort: 5000
   type: ClusterIP


### PR DESCRIPTION
This specifies the command that should be run when the container starts, and uses the default port rather than port 8000