### PR TITLE
remove the pybot and slack tokens not related to the slack-service

### DIFF
--- a/kubernetes/operationcode_backend/base/deployment.yaml
+++ b/kubernetes/operationcode_backend/base/deployment.yaml
@@ -24,11 +24,6 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: airtable_api_key
-        - name: SLACK_LEGACY_ADMIN_TOKEN 
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_legacy_admin_token 
         - name: AIRTABLE_BASE_ID
           valueFrom:
             secretKeyRef:
@@ -49,11 +44,6 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: git_hub_oauth_token
-        - name: PY_BOT_AUTH_KEY
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: py_bot_auth_key
         - name: POSTGRES_HOST
           value: opcode-postgres
         - name: REDIS_URL
@@ -65,16 +55,6 @@ spec:
             secretKeyRef:
               name: backend-secrets
               key: postgres_user
-        - name: SLACK_SUBDOMAIN
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_subdomain
-        - name: SLACK_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_token
         - name: JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:
@@ -131,21 +111,6 @@ spec:
           value: opcode-postgres
         - name: REDIS_URL
           value: redis://opcode-redis:6379/0
-        - name: SLACK_SUBDOMAIN
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_subdomain
-        - name: SLACK_LEGACY_ADMIN_TOKEN 
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_legacy_admin_token 
-        - name: SLACK_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: backend-secrets
-              key: slack_token        
         - name: SENDGRID_PASSWORD 
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Removing the slack change to match this:
https://github.com/OperationCode/operationcode_backend/pull/508

Also removing the PYBOT_AUTH_TOKEN as that was never used and it's not removed from backend-secrets.