### PR TITLE
Add DNS record for pybot subdomain

### DIFF
--- a/dns/operationcode.org/records.tf
+++ b/dns/operationcode.org/records.tf
@@ -19,6 +19,13 @@ resource "dnsimple_record" "dashboards" {
   value = "${var.k8s-cluster-ingress}"
 }
 
+resource "dnsimple_record" "pybot" {
+  domain = "${var.hosted-zone}"
+  name = "pybot"
+  type = "CNAME"
+  value = "${var.pybot-lb-ingress}"
+}
+
 resource "dnsimple_record" "resources_api" {
   domain = "${var.hosted-zone}"
   name = "resources"

--- a/dns/operationcode.org/terraform.tfvars
+++ b/dns/operationcode.org/terraform.tfvars
@@ -6,3 +6,4 @@ terragrunt = {
 
 hosted-zone = "operationcode.org"
 k8s-cluster-ingress = "ac206d147f3ed11e7a802062a4d50822-1344197385.us-east-2.elb.amazonaws.com"
+pybot-lb-ingress = "pyback-lb-197482116.us-east-2.elb.amazonaws.com"

--- a/dns/operationcode.org/variables.tf
+++ b/dns/operationcode.org/variables.tf
@@ -7,3 +7,8 @@ variable "k8s-cluster-ingress" {
   description = "Load balancer URL for the Kubernetes ingress"
   type = "string"
 }
+
+variable "pybot-lb-ingress" {
+  description = "Load balancer URL for pybot subdomain ingress"
+  type = "string"
+}


### PR DESCRIPTION
Adding the previously created DNS record for the pybot.operationcode.org subdomain to terra, as well as associated ingress url variable