### PR TITLE
Add TXT record for verification

### DIFF
--- a/dns/operationcode.org/records.tf
+++ b/dns/operationcode.org/records.tf
@@ -1,6 +1,6 @@
 resource "dnsimple_record" "www" {
   domain = "${var.hosted-zone}"
-  name = ""
+  name = "_now"
   type = "TXT"
   value = "Qmd8XawRvuECtFLQm8SytbgcW2PV2jthtfMy7ujLnTN2gL"
 }

--- a/dns/operationcode.org/records.tf
+++ b/dns/operationcode.org/records.tf
@@ -1,3 +1,10 @@
+resource "dnsimple_record" "www" {
+  domain = "${var.hosted-zone}"
+  name = ""
+  type = "TXT"
+  value = "Qmd8XawRvuECtFLQm8SytbgcW2PV2jthtfMy7ujLnTN2gL"
+}
+
 resource "dnsimple_record" "api" {
   domain = "${var.hosted-zone}"
   name = "api"


### PR DESCRIPTION
```
b) Add a DNS TXT record with the name and value shown below.

     name        type        value
     _now        TXT         Qmd8XawRvuECtFLQm8SytbgcW2PV2jthtfMy7ujLnTN2gL

We will run a verification for you and you will receive an email upon completion.
If you want to force running a verification, you can run `now domains verify <domain>`
Read more: https://err.sh/now-cli/domain-verification
````