### PR TITLE
Add CNAME for Now

### DIFF
--- a/dns/operationcode.org/records.tf
+++ b/dns/operationcode.org/records.tf
@@ -5,6 +5,13 @@ resource "dnsimple_record" "www" {
   value = "Qmd8XawRvuECtFLQm8SytbgcW2PV2jthtfMy7ujLnTN2gL"
 }
 
+resource "dnsimple_record" "www" {
+  domain = "${var.hosted-zone}"
+  name = ""
+  type = "CNAME"
+  value = "alias.zeit.co"
+}
+
 resource "dnsimple_record" "api" {
   domain = "${var.hosted-zone}"
   name = "api"


### PR DESCRIPTION
With #100 merged...
![Screen Shot 2019-05-27 at 2 38 26 PM](https://user-images.githubusercontent.com/9523719/58440270-bfe96980-808d-11e9-9b36-88f254eed6a9.png)

From https://zeit.co/docs/v2/domains-and-aliases/adding-a-domain#preserving-existing-nameservers-with-cname:

"If you need to preserve the current nameservers of a domain, or need to use an alternative method of pointing to Now, you can do so after TXT verification by creating a CNAME record with your domain provider with the value of alias.zeit.co.

Using this method means that you will not be using ZEIT DNS and your domain will be marked as external.

For a greater advantage with Now and your domain, we strongly recommend using the nameservers method."