### PR TITLE
Add Algolia related environment variables

### DIFF
--- a/kubernetes/resources_api/base/deployment.yaml
+++ b/kubernetes/resources_api/base/deployment.yaml
@@ -26,6 +26,20 @@ spec:
             secretKeyRef:
               name: resources-api-secrets
               key: postgres_password
+        - name:  APPLICATION_ID
+          valueFrom:
+            secretKeyRef:
+              name: resources-api-secrets
+              key: algolia_app_id
+        - name: API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: resources-api-secrets
+              key: algolia_api_key
+        - name: INDEX_NAME
+          value: resources_api
+        - name: INDEX_SEARCHED
+          value: false
         - name: POSTGRES_DB
           value: resources_api
         - name: POSTGRES_HOST


### PR DESCRIPTION
The latest image of the Resources API requires some additional environment variables to run. Two of these variables are secret, the other two are non-sensitive. This will need to be merged, and a change to the k8s secrets file will also need to be made.