### PR TITLE
Add fallback docker images for BE

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/prod/deployment.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/deployment.yaml
@@ -7,6 +7,7 @@ spec:
     spec:
       containers:
         - name: app
+          image: operationcode/back-end:master
           env:
             - name: DB_HOST
               value: python-prod.czwauqf3tjaz.us-east-2.rds.amazonaws.com
@@ -15,6 +16,6 @@ spec:
             - name: EXTRA_HOSTS
               value: api.operationcode.org
             - name: RELEASE
-              value: 1.0.0
+              value: 1.0.1
             - name: SITE_ID
               value: "4"

--- a/kubernetes/operationcode_python_backend/overlays/staging/deployment.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/deployment.yaml
@@ -7,10 +7,11 @@ spec:
     spec:
       containers:
         - name: app
+          image: operationcode/back-end:staging
           env:
             - name: DB_HOST
               value: python-staging.czwauqf3tjaz.us-east-2.rds.amazonaws.com
             - name: ENVIRONMENT
               value: aws_staging
             - name: RELEASE
-              value: 1.0.0
+              value: 1.0.1


### PR DESCRIPTION
Configures the BE prod/staging with fallback images/tags.

When a new image is deployed it's done so using a unique tag - however the same image is also tagged with master or staging and pushed to DockerHub as well.