### PR TITLE
Switch staging resources_api db url

### DIFF
--- a/kubernetes/resources_api/overlays/staging/database-service.yaml
+++ b/kubernetes/resources_api/overlays/staging/database-service.yaml
@@ -4,4 +4,4 @@ metadata:
   name: resources-postgres
 spec:
   type: ExternalName
-  externalName: resources-api-20190523.czwauqf3tjaz.us-east-2.rds.amazonaws.com
+  externalName: python-staging.czwauqf3tjaz.us-east-2.rds.amazonaws.com


### PR DESCRIPTION
Configures the resources_api staging environment to use the newly created database on the BE's RDS instance