### PR TITLE
Disable server tokens

### DIFF
--- a/kubernetes/nginx-ingress-controller/base/configmap.yaml
+++ b/kubernetes/nginx-ingress-controller/base/configmap.yaml
@@ -7,6 +7,7 @@ data:
   use-proxy-protocol: "true"
   hsts-include-subdomains: "false"
   server-name-hash-bucket-size: "256"
+  server-tokens: "false"
 kind: ConfigMap
 metadata:
   name: nginx-configuration


### PR DESCRIPTION
The current configuration leaks the version of nginx we're using. Granted, an attacker could just look in this open source repo and figure out what version of nginx we're using, but still. I think best practices are always good to follow.

P.S., we may want to consider upgrading to a new version of `ingress-nginx` soon, we're pretty far behind.