### PR TITLE
Fix API host names and add health checking for the API service

### DIFF
--- a/kubernetes/operationcode_python_backend/base/deployment.yaml
+++ b/kubernetes/operationcode_python_backend/base/deployment.yaml
@@ -28,6 +28,18 @@ spec:
           requests:
             memory: 200Mi
             cpu: 100m
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 20
         env:
         - name: DB_HOST
           value: # Requires overlay

--- a/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
@@ -20,4 +21,10 @@ spec:
         backend:
           serviceName: back-end-service
           servicePort: 80
-
+  - host: api.operationcode.org
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: back-end-service
+          servicePort: 80

--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
@@ -14,6 +15,13 @@ metadata:
 spec:
   rules:
   - host: backend-staging.k8s.operationcode.org
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: back-end-service
+          servicePort: 80
+  - host: api.staging.operationcode.org
     http:
       paths:
       - path: /*

--- a/kubernetes/resources_api/overlays/prod/ingress.yaml
+++ b/kubernetes/resources_api/overlays/prod/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
@@ -20,4 +21,10 @@ spec:
         backend:
           serviceName: resources-api-service
           servicePort: 80
-
+  - host: resources.operationcode.org
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: resources-api-service
+          servicePort: 80

--- a/kubernetes/resources_api/overlays/staging/ingress.yaml
+++ b/kubernetes/resources_api/overlays/staging/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
@@ -20,4 +21,10 @@ spec:
         backend:
           serviceName: resources-api-service
           servicePort: 80
-
+  - host: resources.staging.operationcode.org
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: resources-api-service
+          servicePort: 80


### PR DESCRIPTION
Add old/proper hostnames so that ALB doesn't reject them, add an ALB and kube-level health check

FWIW, I've already pushed these changes up to staging and they look good there

Signed-off-by: Irving Popovetsky <irving@popovetsky.com>