### PR TITLE
Force redirect of HTTP to HTTPS

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
@@ -16,19 +16,11 @@ spec:
   rules:
   # http redirect must come first
   - http:
-    paths:
-      - path: /*
-        backend:
-          serviceName: ssl-redirect
-          servicePort: use-annotation
-      - path: /users/*
-        backend:
-          serviceName: user-service
-          servicePort: 80
-      - path: /*
-        backend:
-          serviceName: default-service
-          servicePort: 80
+      paths:
+        - path: /*
+          backend:
+            serviceName: ssl-redirect
+            servicePort: use-annotation
   # back-end production
   - host: backend.k8s.operationcode.org
     http:

--- a/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
@@ -6,13 +6,29 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
     alb.ingress.kubernetes.io/healthcheck-path: /healthz
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
   labels:
     app: back-end
 spec:
   rules:
+  # http redirect must come first
+  - http:
+    paths:
+      - path: /*
+        backend:
+          serviceName: ssl-redirect
+          servicePort: use-annotation
+      - path: /users/*
+        backend:
+          serviceName: user-service
+          servicePort: 80
+      - path: /*
+        backend:
+          serviceName: default-service
+          servicePort: 80
   # back-end production
   - host: backend.k8s.operationcode.org
     http:

--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -16,19 +16,11 @@ spec:
   rules:
   # http redirect must come first
   - http:
-    paths:
-      - path: /*
-        backend:
-          serviceName: ssl-redirect
-          servicePort: use-annotation
-      - path: /users/*
-        backend:
-          serviceName: user-service
-          servicePort: 80
-      - path: /*
-        backend:
-          serviceName: default-service
-          servicePort: 80
+      paths:
+        - path: /*
+          backend:
+            serviceName: ssl-redirect
+            servicePort: use-annotation
   # back-end staging
   - host: backend-staging.k8s.operationcode.org
     http:

--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -6,13 +6,29 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
     alb.ingress.kubernetes.io/healthcheck-path: /healthz
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
   labels:
     app: back-end
 spec:
   rules:
+  # http redirect must come first
+  - http:
+    paths:
+      - path: /*
+        backend:
+          serviceName: ssl-redirect
+          servicePort: use-annotation
+      - path: /users/*
+        backend:
+          serviceName: user-service
+          servicePort: 80
+      - path: /*
+        backend:
+          serviceName: default-service
+          servicePort: 80
   # back-end staging
   - host: backend-staging.k8s.operationcode.org
     http:


### PR DESCRIPTION
I don't like that when you visit http://resources.operationcode.org it doesn't automatically redirect you to https://resources.operationcode.org

I hope this fixes that? I'm not super confident. Please advise