### PR TITLE
Eksctl install link fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform/
+.DS_Store

--- a/SETUP.md
+++ b/SETUP.md
@@ -5,6 +5,6 @@ Greetings! Much of Operation Code's web site runs in a [Kubernetes](https://kube
 # Getting access to the cluster
 
 1. Ensure you have AWS access, and the aws CLI is operating correctly
-2. Install eksctl: https://eksctl.io/introduction/installation/
+2. Install eksctl: https://eksctl.io/introduction/#installation
 3. Run: `eksctl utils write-kubeconfig --region us-east-2 --cluster operationcode-backend`
 4. Verify everything works: `kubectl get namespaces`


### PR DESCRIPTION
the eksctl install link was returning a 404 error. Added the updated link. Also added '.DS_Store' to the git ignore for those of us on macs.