### PR TITLE
Run the production server instead of the development server

### DIFF
--- a/kubernetes/resources_api/base/deployment.yaml
+++ b/kubernetes/resources_api/base/deployment.yaml
@@ -21,8 +21,8 @@ spec:
       containers:
       - name: app
         image: operationcode/resources-api:latest
-        command: ["flask"]
-        args: ["run", "-h", "0.0.0.0"]
+        command: ["uwsgi"]
+        args: ["--ini", "app.ini"]
         imagePullPolicy: Always
         ports:
         - containerPort: 5000


### PR DESCRIPTION
I was naive when I did #91. The container should not start with `flask` because that's the development server 🤦 

Production should be running uwsgi, which is why the [Dockerfile specifies that](https://github.com/OperationCode/resources_api/blob/664532ee3ab4cb7c5000166d84ba371cf8b7713a/Dockerfile#L28).

I want to say part of this had to do with the fact that the `/metrics` endpoint was publicly accessible, so we're going to want to make that only accessible within the cluster and I'm not sure how to do that. But once we start getting a production load on the server, we really need to not be running the dev server anymore.