### PR TITLE
Redirect /metrics and /healthz to root in staging

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/actions.redirect-to-root: '{"Type":"redirect","RedirectConfig":{"Host":"resources.staging.operationcode.org","Path":"/","Port":"443","Protocol":"HTTPS","StatusCode":"HTTP_302"}}'
   labels:
     app: back-end
 spec:
@@ -44,6 +45,14 @@ spec:
         backend:
           serviceName: resources-api-service
           servicePort: 80
+      - path: /metrics
+        backend:
+          serviceName: redirect-to-root
+          servicePort: use-annotation
+      - path: /healthz
+        backend:
+          serviceName: redirect-to-root
+          servicePort: use-annotation
   - host: resources.staging.operationcode.org
     http:
       paths:

--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -41,10 +41,6 @@ spec:
   - host: resources-staging.k8s.operationcode.org
     http:
       paths:
-      - path: /*
-        backend:
-          serviceName: resources-api-service
-          servicePort: 80
       - path: /metrics
         backend:
           serviceName: redirect-to-root
@@ -53,6 +49,10 @@ spec:
         backend:
           serviceName: redirect-to-root
           servicePort: use-annotation
+      - path: /*
+        backend:
+          serviceName: resources-api-service
+          servicePort: 80
   - host: resources.staging.operationcode.org
     http:
       paths:


### PR DESCRIPTION
I don't know if this will work, but I suspect it will. The goal is to make the `/metrics` and `/healthz` endpoints only available within the cluster. If someone attempts to access them from outside the cluster, they'll be redirected to `/` instead.

If this works in staging, I'll follow up with another PR to update production.