### PR TITLE
Respond with 401 on /metrics staging

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -45,10 +45,6 @@ spec:
         backend:
           serviceName: response-401
           servicePort: use-annotation
-      - path: /healthz
-        backend:
-          serviceName: response-401
-          servicePort: use-annotation
       - path: /*
         backend:
           serviceName: resources-api-service
@@ -56,6 +52,10 @@ spec:
   - host: resources.staging.operationcode.org
     http:
       paths:
+      - path: /metrics
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
       - path: /*
         backend:
           serviceName: resources-api-service


### PR DESCRIPTION
Leave the `/healthz` endpoint publicly accessible for StatusCake, but deny `/metrics` from outside the cluster. This is on staging, an associated PR will be made for production once this is confirmed to work properly.