### PR TITLE
Respond with 401 on /metrics for resources prod

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/actions.response-401: '{"Type":"fixed-response","FixedResponseConfig":{"ContentType":"text/plain","StatusCode":"401","MessageBody":"401 Not Authorized"}}'
   labels:
     app: back-end
 spec:
@@ -40,6 +41,10 @@ spec:
   - host: resources.k8s.operationcode.org
     http:
       paths:
+      - path: /metrics
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
       - path: /*
         backend:
           serviceName: resources-api-service
@@ -47,6 +52,10 @@ spec:
   - host: resources.operationcode.org
     http:
       paths:
+      - path: /metrics
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
       - path: /*
         backend:
           serviceName: resources-api-service


### PR DESCRIPTION
Deny /metrics from outside the cluster on production resources API.