### PR TITLE
Add /metrics/* to 401 list

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
@@ -45,6 +45,10 @@ spec:
         backend:
           serviceName: response-401
           servicePort: use-annotation
+      - path: /metrics/*
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
       - path: /*
         backend:
           serviceName: resources-api-service
@@ -53,6 +57,10 @@ spec:
     http:
       paths:
       - path: /metrics
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
+      - path: /metrics/*
         backend:
           serviceName: response-401
           servicePort: use-annotation

--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -45,6 +45,10 @@ spec:
         backend:
           serviceName: response-401
           servicePort: use-annotation
+      - path: /metrics/*
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
       - path: /*
         backend:
           serviceName: resources-api-service
@@ -53,6 +57,10 @@ spec:
     http:
       paths:
       - path: /metrics
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
+      - path: /metrics/*
         backend:
           serviceName: response-401
           servicePort: use-annotation


### PR DESCRIPTION
Adds `/metrics/*` to the list of paths that return a 401 at the ALB level.