### PR TITLE
Add Python Backend JWT key pair

### DIFF
--- a/kubernetes/operationcode_python_backend/base/deployment.yaml
+++ b/kubernetes/operationcode_python_backend/base/deployment.yaml
@@ -152,6 +152,16 @@ spec:
               key: honeycomb_writekey
         - name: HONEYCOMB_DATASET
           value: production-traces
+        - name: JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: python-backend-secrets
+              key: jwt_secret_key
+        - name: JWT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              name: python-backend-secrets
+              key: jwt_public_key
       volumes:
       - name: python-backend-secrets
         secret:


### PR DESCRIPTION
Adds pub/private key pair that the python backend will use to sign JWTs in an incoming PR.