### PR TITLE
Add JWT_PUBLIC_KEY env var to resources api

### DIFF
--- a/kubernetes/resources_api/base/deployment.yaml
+++ b/kubernetes/resources_api/base/deployment.yaml
@@ -64,6 +64,11 @@ spec:
               key: honeycomb_writekey
         - name: HONEYCOMB_DATASET
           value: production-traces
+        - name: JWT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              name: resources-api-secrets
+              key: jwt_public_key
       volumes:
       - name: resources-api-secrets
         secret:


### PR DESCRIPTION
As of https://github.com/OperationCode/resources_api/pull/325 we now accept a JWT token for the resources API, and we validate it with the public key loaded up as an environment variable. This adds that. Will push up the change to the secret once this is merged