### PR TITLE
Verify ArgoCD works with "main" branch

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -41,6 +41,10 @@ spec:
   - host: resources-staging.k8s.operationcode.org
     http:
       paths:
+        - path: /faketestdestination
+        backend:
+          serviceName: response-401
+          servicePort: use-annotation
       - path: /metrics
         backend:
           serviceName: response-401


### PR DESCRIPTION
I made a pointless change to an endpoint in `resources-staging` to return a 401 if someone tries to go to the `/faketestdestination` endpoint. If argocd syncs as expected I will remove this change.