### PR TITLE
Updated Readme with ergonomic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,28 @@
 <br />
 
 # Operation Code Infra
-Platform infrastructure for the Operation Code site.
+Platform infrastructure for the [Operation Code site](https://operationcode.org/).
 
 [![CircleCI](https://circleci.com/gh/OperationCode/operationcode_infra/tree/master.svg?style=svg)](https://circleci.com/gh/OperationCode/operationcode_infra/tree/master)
 
 ## warning
 
-This repository is using ArgoCD to deploy the Operation Code infrastructure. Changes landed on main in this repository are reflected in the real running infrastructure.
+This repository is using [ArgoCD](https://argoproj.github.io/argo-cd/) to deploy the Operation Code infrastructure. Changes landed on main in this repository are reflected in the real running infrastructure.
 
-To set up your workstation to access our Kubernetes cluster, please see [SETUP.md](SETUP.md) 
+To set up your workstation to access our Kubernetes cluster, please check the below instructions
+
+## Setup
+
+### Operation Code's Kubernetes Cluster.
+Greetings! Much of Operation Code's web site runs in a [Kubernetes](https://kubernetes.io/) cluster.  These instructions will guide you through setting up access to our cluster so you can run rails console, tail logs, and more!   
+
+### Getting access to the cluster
+1. Ensure you have [AWS](https://aws.amazon.com) access, and the [aws CLI](https://aws.amazon.com/cli/) is operating correctly
+2. Install eksctl: https://eksctl.io/introduction/#installation
+3. Run: `eksctl utils write-kubeconfig --region us-east-2 --cluster operationcode-backend`
+4. Verify everything works: `kubectl get namespaces`
+
+
+## Licensing
+ [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)   
+Operation Code Infra is under the [MIT License](/LICENSE).


### PR DESCRIPTION
The following ergonomic changes were made to the readme file : 
1. The Operation Code website was linked in the reference.
2. The SETUP.md file content was added aptly to the readme, it was creating an unnecessary redirect and having the same content in the readme makes it easier for users
3. Added a backlink to ArgoCD
4. Added a backlink to AWS services referred
5. Added the Licensing reference to the readme alongside the MIT License badge like most official repositories
Hence, also closes #167 #168 #169