### PR TITLE
Batch of upgrades and cleanups

### DIFF
--- a/kubernetes/argocd/application-crd.yaml
+++ b/kubernetes/argocd/application-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -16,639 +16,136 @@ spec:
     - apps
     singular: application
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: Application is a definition of Application resource.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        operation:
-          description: Operation contains requested operation parameters.
-          properties:
-            initiatedBy:
-              description: OperationInitiator holds information about the operation
-                initiator
-              properties:
-                automated:
-                  description: Automated is set to true if operation was initiated
-                    automatically by the application controller.
-                  type: boolean
-                username:
-                  description: Name of a user who started operation.
-                  type: string
-              type: object
-            sync:
-              description: SyncOperation contains sync operation details.
-              properties:
-                dryRun:
-                  description: DryRun will perform a `kubectl apply --dry-run` without
-                    actually performing the sync
-                  type: boolean
-                manifests:
-                  description: Manifests is an optional field that overrides sync
-                    source with a local directory for development
-                  items:
-                    type: string
-                  type: array
-                prune:
-                  description: Prune deletes resources that are no longer tracked
-                    in git
-                  type: boolean
-                resources:
-                  description: Resources describes which resources to sync
-                  items:
-                    description: SyncOperationResource contains resources to sync.
-                    properties:
-                      group:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  type: array
-                revision:
-                  description: Revision is the revision in which to sync the application
-                    to. If omitted, will use the revision specified in app spec.
-                  type: string
-                source:
-                  description: Source overrides the source definition set in the application.
-                    This is typically set in a Rollback operation and nil during a
-                    Sync operation
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.sync.status
+      name: Sync Status
+      type: string
+    - jsonPath: .status.health.status
+      name: Health Status
+      type: string
+    - jsonPath: .status.sync.revision
+      name: Revision
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is a definition of Application resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          operation:
+            description: Operation contains information about a requested or running operation
+            properties:
+              info:
+                description: Info is a list of informational items for this operation
+                items:
                   properties:
-                    chart:
-                      description: Chart is a Helm chart name
+                    name:
                       type: string
-                    directory:
-                      description: Directory holds path/directory specific options
-                      properties:
-                        jsonnet:
-                          description: ApplicationSourceJsonnet holds jsonnet specific
-                            options
-                          properties:
-                            extVars:
-                              description: ExtVars is a list of Jsonnet External Variables
-                              items:
-                                description: JsonnetVar is a jsonnet variable
-                                properties:
-                                  code:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                            tlas:
-                              description: TLAS is a list of Jsonnet Top-level Arguments
-                              items:
-                                description: JsonnetVar is a jsonnet variable
-                                properties:
-                                  code:
-                                    type: boolean
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                          type: object
-                        recurse:
-                          type: boolean
-                      type: object
-                    helm:
-                      description: Helm holds helm specific options
-                      properties:
-                        fileParameters:
-                          description: FileParameters are file parameters to the helm
-                            template
-                          items:
-                            description: HelmFileParameter is a file parameter to
-                              a helm template
-                            properties:
-                              name:
-                                description: Name is the name of the helm parameter
-                                type: string
-                              path:
-                                description: Path is the path value for the helm parameter
-                                type: string
-                            type: object
-                          type: array
-                        parameters:
-                          description: Parameters are parameters to the helm template
-                          items:
-                            description: HelmParameter is a parameter to a helm template
-                            properties:
-                              forceString:
-                                description: ForceString determines whether to tell
-                                  Helm to interpret booleans and numbers as strings
-                                type: boolean
-                              name:
-                                description: Name is the name of the helm parameter
-                                type: string
-                              value:
-                                description: Value is the value for the helm parameter
-                                type: string
-                            type: object
-                          type: array
-                        releaseName:
-                          description: The Helm release name. If omitted it will use
-                            the application name
-                          type: string
-                        valueFiles:
-                          description: ValuesFiles is a list of Helm value files to
-                            use when generating a template
-                          items:
-                            type: string
-                          type: array
-                        values:
-                          description: Values is Helm values, typically defined as
-                            a block
-                          type: string
-                      type: object
-                    ksonnet:
-                      description: Ksonnet holds ksonnet specific options
-                      properties:
-                        environment:
-                          description: Environment is a ksonnet application environment
-                            name
-                          type: string
-                        parameters:
-                          description: Parameters are a list of ksonnet component
-                            parameter override values
-                          items:
-                            description: KsonnetParameter is a ksonnet component parameter
-                            properties:
-                              component:
-                                type: string
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                      type: object
-                    kustomize:
-                      description: Kustomize holds kustomize specific options
-                      properties:
-                        commonLabels:
-                          additionalProperties:
-                            type: string
-                          description: CommonLabels adds additional kustomize commonLabels
-                          type: object
-                        images:
-                          description: Images are kustomize image overrides
-                          items:
-                            type: string
-                          type: array
-                        namePrefix:
-                          description: NamePrefix is a prefix appended to resources
-                            for kustomize apps
-                          type: string
-                        nameSuffix:
-                          description: NameSuffix is a suffix appended to resources
-                            for kustomize apps
-                          type: string
-                        version:
-                          description: Version contains optional Kustomize version
-                          type: string
-                      type: object
-                    path:
-                      description: Path is a directory path within the Git repository
-                      type: string
-                    plugin:
-                      description: ConfigManagementPlugin holds config management
-                        plugin specific options
-                      properties:
-                        env:
-                          items:
-                            properties:
-                              name:
-                                description: the name, usually uppercase
-                                type: string
-                              value:
-                                description: the value
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        name:
-                          type: string
-                      type: object
-                    repoURL:
-                      description: RepoURL is the repository URL of the application
-                        manifests
-                      type: string
-                    targetRevision:
-                      description: TargetRevision defines the commit, tag, or branch
-                        in which to sync the application to. If omitted, will sync
-                        to HEAD
+                    value:
                       type: string
                   required:
-                  - repoURL
+                  - name
+                  - value
                   type: object
-                syncOptions:
-                  description: SyncOptions provide per-sync sync-options, e.g. Validate=false
-                  items:
-                    type: string
-                  type: array
-                syncStrategy:
-                  description: SyncStrategy describes how to perform the sync
-                  properties:
-                    apply:
-                      description: Apply wil perform a `kubectl apply` to perform
-                        the sync.
-                      properties:
-                        force:
-                          description: Force indicates whether or not to supply the
-                            --force flag to `kubectl apply`. The --force flag deletes
-                            and re-create the resource, when PATCH encounters conflict
-                            and has retried for 5 times.
-                          type: boolean
-                      type: object
-                    hook:
-                      description: Hook will submit any referenced resources to perform
-                        the sync. This is the default strategy
-                      properties:
-                        force:
-                          description: Force indicates whether or not to supply the
-                            --force flag to `kubectl apply`. The --force flag deletes
-                            and re-create the resource, when PATCH encounters conflict
-                            and has retried for 5 times.
-                          type: boolean
-                      type: object
-                  type: object
-              type: object
-          type: object
-        spec:
-          description: ApplicationSpec represents desired application state. Contains
-            link to repository with application definition and additional parameters
-            link definition revision.
-          properties:
-            destination:
-              description: Destination overrides the kubernetes server and namespace
-                defined in the environment ksonnet app.yaml
-              properties:
-                namespace:
-                  description: Namespace overrides the environment namespace value
-                    in the ksonnet app.yaml
-                  type: string
-                server:
-                  description: Server overrides the environment server value in the
-                    ksonnet app.yaml
-                  type: string
-              type: object
-            ignoreDifferences:
-              description: IgnoreDifferences controls resources fields which should
-                be ignored during comparison
-              items:
-                description: ResourceIgnoreDifferences contains resource filter and
-                  list of json paths which should be ignored during comparison with
-                  live state.
+                type: array
+              initiatedBy:
+                description: InitiatedBy contains information about who initiated the operations
                 properties:
-                  group:
+                  automated:
+                    description: Automated is set to true if operation was initiated automatically by the application controller.
+                    type: boolean
+                  username:
+                    description: Username contains the name of a user who started operation
                     type: string
-                  jsonPointers:
+                type: object
+              retry:
+                description: Retry controls the strategy to apply if a sync fails
+                properties:
+                  backoff:
+                    description: Backoff controls how to backoff on subsequent retries of failed syncs
+                    properties:
+                      duration:
+                        description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                        type: string
+                      factor:
+                        description: Factor is a factor to multiply the base duration after each failed retry
+                        format: int64
+                        type: integer
+                      maxDuration:
+                        description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                        type: string
+                    type: object
+                  limit:
+                    description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                    format: int64
+                    type: integer
+                type: object
+              sync:
+                description: Sync contains parameters for the operation
+                properties:
+                  dryRun:
+                    description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+                    type: boolean
+                  manifests:
+                    description: Manifests is an optional field that overrides sync source with a local directory for development
                     items:
                       type: string
                     type: array
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - jsonPointers
-                - kind
-                type: object
-              type: array
-            info:
-              description: Infos contains a list of useful information (URLs, email
-                addresses, and plain text) that relates to the application
-              items:
-                properties:
-                  name:
-                    type: string
-                  value:
-                    type: string
-                required:
-                - name
-                - value
-                type: object
-              type: array
-            project:
-              description: Project is a application project name. Empty name means
-                that application belongs to 'default' project.
-              type: string
-            revisionHistoryLimit:
-              description: This limits this number of items kept in the apps revision
-                history. This should only be changed in exceptional circumstances.
-                Setting to zero will store no history. This will reduce storage used.
-                Increasing will increase the space used to store the history, so we
-                do not recommend increasing it. Default is 10.
-              format: int64
-              type: integer
-            source:
-              description: Source is a reference to the location ksonnet application
-                definition
-              properties:
-                chart:
-                  description: Chart is a Helm chart name
-                  type: string
-                directory:
-                  description: Directory holds path/directory specific options
-                  properties:
-                    jsonnet:
-                      description: ApplicationSourceJsonnet holds jsonnet specific
-                        options
+                  prune:
+                    description: Prune specifies to delete resources from the cluster that are no longer tracked in git
+                    type: boolean
+                  resources:
+                    description: Resources describes which resources shall be part of the sync
+                    items:
+                      description: SyncOperationResource contains resources to sync.
                       properties:
-                        extVars:
-                          description: ExtVars is a list of Jsonnet External Variables
-                          items:
-                            description: JsonnetVar is a jsonnet variable
-                            properties:
-                              code:
-                                type: boolean
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        tlas:
-                          description: TLAS is a list of Jsonnet Top-level Arguments
-                          items:
-                            description: JsonnetVar is a jsonnet variable
-                            properties:
-                              code:
-                                type: boolean
-                              name:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - kind
+                      - name
                       type: object
-                    recurse:
-                      type: boolean
-                  type: object
-                helm:
-                  description: Helm holds helm specific options
-                  properties:
-                    fileParameters:
-                      description: FileParameters are file parameters to the helm
-                        template
-                      items:
-                        description: HelmFileParameter is a file parameter to a helm
-                          template
-                        properties:
-                          name:
-                            description: Name is the name of the helm parameter
-                            type: string
-                          path:
-                            description: Path is the path value for the helm parameter
-                            type: string
-                        type: object
-                      type: array
-                    parameters:
-                      description: Parameters are parameters to the helm template
-                      items:
-                        description: HelmParameter is a parameter to a helm template
-                        properties:
-                          forceString:
-                            description: ForceString determines whether to tell Helm
-                              to interpret booleans and numbers as strings
-                            type: boolean
-                          name:
-                            description: Name is the name of the helm parameter
-                            type: string
-                          value:
-                            description: Value is the value for the helm parameter
-                            type: string
-                        type: object
-                      type: array
-                    releaseName:
-                      description: The Helm release name. If omitted it will use the
-                        application name
-                      type: string
-                    valueFiles:
-                      description: ValuesFiles is a list of Helm value files to use
-                        when generating a template
-                      items:
-                        type: string
-                      type: array
-                    values:
-                      description: Values is Helm values, typically defined as a block
-                      type: string
-                  type: object
-                ksonnet:
-                  description: Ksonnet holds ksonnet specific options
-                  properties:
-                    environment:
-                      description: Environment is a ksonnet application environment
-                        name
-                      type: string
-                    parameters:
-                      description: Parameters are a list of ksonnet component parameter
-                        override values
-                      items:
-                        description: KsonnetParameter is a ksonnet component parameter
-                        properties:
-                          component:
-                            type: string
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                  type: object
-                kustomize:
-                  description: Kustomize holds kustomize specific options
-                  properties:
-                    commonLabels:
-                      additionalProperties:
-                        type: string
-                      description: CommonLabels adds additional kustomize commonLabels
-                      type: object
-                    images:
-                      description: Images are kustomize image overrides
-                      items:
-                        type: string
-                      type: array
-                    namePrefix:
-                      description: NamePrefix is a prefix appended to resources for
-                        kustomize apps
-                      type: string
-                    nameSuffix:
-                      description: NameSuffix is a suffix appended to resources for
-                        kustomize apps
-                      type: string
-                    version:
-                      description: Version contains optional Kustomize version
-                      type: string
-                  type: object
-                path:
-                  description: Path is a directory path within the Git repository
-                  type: string
-                plugin:
-                  description: ConfigManagementPlugin holds config management plugin
-                    specific options
-                  properties:
-                    env:
-                      items:
-                        properties:
-                          name:
-                            description: the name, usually uppercase
-                            type: string
-                          value:
-                            description: the value
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    name:
-                      type: string
-                  type: object
-                repoURL:
-                  description: RepoURL is the repository URL of the application manifests
-                  type: string
-                targetRevision:
-                  description: TargetRevision defines the commit, tag, or branch in
-                    which to sync the application to. If omitted, will sync to HEAD
-                  type: string
-              required:
-              - repoURL
-              type: object
-            syncPolicy:
-              description: SyncPolicy controls when a sync will be performed
-              properties:
-                automated:
-                  description: Automated will keep an application synced to the target
-                    revision
-                  properties:
-                    prune:
-                      description: 'Prune will prune resources automatically as part
-                        of automated sync (default: false)'
-                      type: boolean
-                    selfHeal:
-                      description: 'SelfHeal enables auto-syncing if  (default: false)'
-                      type: boolean
-                  type: object
-                syncOptions:
-                  description: Options allow youe to specify whole app sync-options
-                  items:
-                    type: string
-                  type: array
-              type: object
-          required:
-          - destination
-          - project
-          - source
-          type: object
-        status:
-          description: ApplicationStatus contains information about application sync,
-            health status
-          properties:
-            conditions:
-              items:
-                description: ApplicationCondition contains details about current application
-                  condition
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the time the condition was
-                      first observed.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message contains human-readable message indicating
-                      details about condition
-                    type: string
-                  type:
-                    description: Type is an application condition type
-                    type: string
-                required:
-                - message
-                - type
-                type: object
-              type: array
-            health:
-              properties:
-                message:
-                  type: string
-                status:
-                  type: string
-              type: object
-            history:
-              description: RevisionHistories is a array of history, oldest first and
-                newest last
-              items:
-                description: RevisionHistory contains information relevant to an application
-                  deployment
-                properties:
-                  deployedAt:
-                    format: date-time
-                    type: string
-                  id:
-                    format: int64
-                    type: integer
+                    type: array
                   revision:
+                    description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
                     type: string
                   source:
-                    description: ApplicationSource contains information about github
-                      repository, path within repository and target application environment.
+                    description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
                     properties:
                       chart:
-                        description: Chart is a Helm chart name
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                         type: string
                       directory:
                         description: Directory holds path/directory specific options
                         properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                            type: string
                           jsonnet:
-                            description: ApplicationSourceJsonnet holds jsonnet specific
-                              options
+                            description: Jsonnet holds options specific to Jsonnet
                             properties:
                               extVars:
-                                description: ExtVars is a list of Jsonnet External
-                                  Variables
+                                description: ExtVars is a list of Jsonnet External Variables
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -661,10 +158,15 @@ spec:
                                   - value
                                   type: object
                                 type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
+                                type: array
                               tlas:
                                 description: TLAS is a list of Jsonnet Top-level Arguments
                                 items:
-                                  description: JsonnetVar is a jsonnet variable
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                   properties:
                                     code:
                                       type: boolean
@@ -679,73 +181,66 @@ spec:
                                 type: array
                             type: object
                           recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
                             type: boolean
                         type: object
                       helm:
                         description: Helm holds helm specific options
                         properties:
                           fileParameters:
-                            description: FileParameters are file parameters to the
-                              helm template
+                            description: FileParameters are file parameters to the helm template
                             items:
-                              description: HelmFileParameter is a file parameter to
-                                a helm template
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                               properties:
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 path:
-                                  description: Path is the path value for the helm
-                                    parameter
+                                  description: Path is the path to the file containing the values for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           parameters:
-                            description: Parameters are parameters to the helm template
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                             items:
-                              description: HelmParameter is a parameter to a helm
-                                template
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
                               properties:
                                 forceString:
-                                  description: ForceString determines whether to tell
-                                    Helm to interpret booleans and numbers as strings
+                                  description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                   type: boolean
                                 name:
-                                  description: Name is the name of the helm parameter
+                                  description: Name is the name of the Helm parameter
                                   type: string
                                 value:
-                                  description: Value is the value for the helm parameter
+                                  description: Value is the value for the Helm parameter
                                   type: string
                               type: object
                             type: array
                           releaseName:
-                            description: The Helm release name. If omitted it will
-                              use the application name
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                             type: string
                           valueFiles:
-                            description: ValuesFiles is a list of Helm value files
-                              to use when generating a template
+                            description: ValuesFiles is a list of Helm value files to use when generating a template
                             items:
                               type: string
                             type: array
                           values:
-                            description: Values is Helm values, typically defined
-                              as a block
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                            type: string
+                          version:
+                            description: Version is the Helm version to use for templating (either "2" or "3")
                             type: string
                         type: object
                       ksonnet:
                         description: Ksonnet holds ksonnet specific options
                         properties:
                           environment:
-                            description: Environment is a ksonnet application environment
-                              name
+                            description: Environment is a ksonnet application environment name
                             type: string
                           parameters:
-                            description: Parameters are a list of ksonnet component
-                              parameter override values
+                            description: Parameters are a list of ksonnet component parameter override values
                             items:
-                              description: KsonnetParameter is a ksonnet component
-                                parameter
+                              description: KsonnetParameter is a ksonnet component parameter
                               properties:
                                 component:
                                   type: string
@@ -762,43 +257,48 @@ spec:
                       kustomize:
                         description: Kustomize holds kustomize specific options
                         properties:
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                            type: object
                           commonLabels:
                             additionalProperties:
                               type: string
-                            description: CommonLabels adds additional kustomize commonLabels
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
                             type: object
                           images:
-                            description: Images are kustomize image overrides
+                            description: Images is a list of Kustomize image override specifications
                             items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                               type: string
                             type: array
                           namePrefix:
-                            description: NamePrefix is a prefix appended to resources
-                              for kustomize apps
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
                             type: string
                           nameSuffix:
-                            description: NameSuffix is a suffix appended to resources
-                              for kustomize apps
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
                             type: string
                           version:
-                            description: Version contains optional Kustomize version
+                            description: Version controls which version of Kustomize to use for rendering manifests
                             type: string
                         type: object
                       path:
-                        description: Path is a directory path within the Git repository
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                         type: string
                       plugin:
-                        description: ConfigManagementPlugin holds config management
-                          plugin specific options
+                        description: ConfigManagementPlugin holds config management plugin specific options
                         properties:
                           env:
+                            description: Env is a list of environment variable entries
                             items:
+                              description: EnvEntry represents an entry in the application's environment
                               properties:
                                 name:
-                                  description: the name, usually uppercase
+                                  description: Name is the name of the variable, usually expressed in uppercase
                                   type: string
                                 value:
-                                  description: the value
+                                  description: Value is the value of the variable
                                   type: string
                               required:
                               - name
@@ -809,685 +309,414 @@ spec:
                             type: string
                         type: object
                       repoURL:
-                        description: RepoURL is the repository URL of the application
-                          manifests
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                         type: string
                       targetRevision:
-                        description: TargetRevision defines the commit, tag, or branch
-                          in which to sync the application to. If omitted, will sync
-                          to HEAD
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                         type: string
                     required:
                     - repoURL
                     type: object
-                required:
-                - deployedAt
-                - id
-                - revision
-                type: object
-              type: array
-            observedAt:
-              description: ObservedAt indicates when the application state was updated
-                without querying latest git state
-              format: date-time
-              type: string
-            operationState:
-              description: OperationState contains information about state of currently
-                performing operation on application.
-              properties:
-                finishedAt:
-                  description: FinishedAt contains time of operation completion
-                  format: date-time
-                  type: string
-                message:
-                  description: Message hold any pertinent messages when attempting
-                    to perform operation (typically errors).
-                  type: string
-                operation:
-                  description: Operation is the original requested operation
-                  properties:
-                    initiatedBy:
-                      description: OperationInitiator holds information about the
-                        operation initiator
-                      properties:
-                        automated:
-                          description: Automated is set to true if operation was initiated
-                            automatically by the application controller.
-                          type: boolean
-                        username:
-                          description: Name of a user who started operation.
-                          type: string
-                      type: object
-                    sync:
-                      description: SyncOperation contains sync operation details.
-                      properties:
-                        dryRun:
-                          description: DryRun will perform a `kubectl apply --dry-run`
-                            without actually performing the sync
-                          type: boolean
-                        manifests:
-                          description: Manifests is an optional field that overrides
-                            sync source with a local directory for development
-                          items:
-                            type: string
-                          type: array
-                        prune:
-                          description: Prune deletes resources that are no longer
-                            tracked in git
-                          type: boolean
-                        resources:
-                          description: Resources describes which resources to sync
-                          items:
-                            description: SyncOperationResource contains resources
-                              to sync.
-                            properties:
-                              group:
-                                type: string
-                              kind:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          type: array
-                        revision:
-                          description: Revision is the revision in which to sync the
-                            application to. If omitted, will use the revision specified
-                            in app spec.
-                          type: string
-                        source:
-                          description: Source overrides the source definition set
-                            in the application. This is typically set in a Rollback
-                            operation and nil during a Sync operation
-                          properties:
-                            chart:
-                              description: Chart is a Helm chart name
-                              type: string
-                            directory:
-                              description: Directory holds path/directory specific
-                                options
-                              properties:
-                                jsonnet:
-                                  description: ApplicationSourceJsonnet holds jsonnet
-                                    specific options
-                                  properties:
-                                    extVars:
-                                      description: ExtVars is a list of Jsonnet External
-                                        Variables
-                                      items:
-                                        description: JsonnetVar is a jsonnet variable
-                                        properties:
-                                          code:
-                                            type: boolean
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    tlas:
-                                      description: TLAS is a list of Jsonnet Top-level
-                                        Arguments
-                                      items:
-                                        description: JsonnetVar is a jsonnet variable
-                                        properties:
-                                          code:
-                                            type: boolean
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                  type: object
-                                recurse:
-                                  type: boolean
-                              type: object
-                            helm:
-                              description: Helm holds helm specific options
-                              properties:
-                                fileParameters:
-                                  description: FileParameters are file parameters
-                                    to the helm template
-                                  items:
-                                    description: HelmFileParameter is a file parameter
-                                      to a helm template
-                                    properties:
-                                      name:
-                                        description: Name is the name of the helm
-                                          parameter
-                                        type: string
-                                      path:
-                                        description: Path is the path value for the
-                                          helm parameter
-                                        type: string
-                                    type: object
-                                  type: array
-                                parameters:
-                                  description: Parameters are parameters to the helm
-                                    template
-                                  items:
-                                    description: HelmParameter is a parameter to a
-                                      helm template
-                                    properties:
-                                      forceString:
-                                        description: ForceString determines whether
-                                          to tell Helm to interpret booleans and numbers
-                                          as strings
-                                        type: boolean
-                                      name:
-                                        description: Name is the name of the helm
-                                          parameter
-                                        type: string
-                                      value:
-                                        description: Value is the value for the helm
-                                          parameter
-                                        type: string
-                                    type: object
-                                  type: array
-                                releaseName:
-                                  description: The Helm release name. If omitted it
-                                    will use the application name
-                                  type: string
-                                valueFiles:
-                                  description: ValuesFiles is a list of Helm value
-                                    files to use when generating a template
-                                  items:
-                                    type: string
-                                  type: array
-                                values:
-                                  description: Values is Helm values, typically defined
-                                    as a block
-                                  type: string
-                              type: object
-                            ksonnet:
-                              description: Ksonnet holds ksonnet specific options
-                              properties:
-                                environment:
-                                  description: Environment is a ksonnet application
-                                    environment name
-                                  type: string
-                                parameters:
-                                  description: Parameters are a list of ksonnet component
-                                    parameter override values
-                                  items:
-                                    description: KsonnetParameter is a ksonnet component
-                                      parameter
-                                    properties:
-                                      component:
-                                        type: string
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                              type: object
-                            kustomize:
-                              description: Kustomize holds kustomize specific options
-                              properties:
-                                commonLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: CommonLabels adds additional kustomize
-                                    commonLabels
-                                  type: object
-                                images:
-                                  description: Images are kustomize image overrides
-                                  items:
-                                    type: string
-                                  type: array
-                                namePrefix:
-                                  description: NamePrefix is a prefix appended to
-                                    resources for kustomize apps
-                                  type: string
-                                nameSuffix:
-                                  description: NameSuffix is a suffix appended to
-                                    resources for kustomize apps
-                                  type: string
-                                version:
-                                  description: Version contains optional Kustomize
-                                    version
-                                  type: string
-                              type: object
-                            path:
-                              description: Path is a directory path within the Git
-                                repository
-                              type: string
-                            plugin:
-                              description: ConfigManagementPlugin holds config management
-                                plugin specific options
-                              properties:
-                                env:
-                                  items:
-                                    properties:
-                                      name:
-                                        description: the name, usually uppercase
-                                        type: string
-                                      value:
-                                        description: the value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                              type: object
-                            repoURL:
-                              description: RepoURL is the repository URL of the application
-                                manifests
-                              type: string
-                            targetRevision:
-                              description: TargetRevision defines the commit, tag,
-                                or branch in which to sync the application to. If
-                                omitted, will sync to HEAD
-                              type: string
-                          required:
-                          - repoURL
-                          type: object
-                        syncOptions:
-                          description: SyncOptions provide per-sync sync-options,
-                            e.g. Validate=false
-                          items:
-                            type: string
-                          type: array
-                        syncStrategy:
-                          description: SyncStrategy describes how to perform the sync
-                          properties:
-                            apply:
-                              description: Apply wil perform a `kubectl apply` to
-                                perform the sync.
-                              properties:
-                                force:
-                                  description: Force indicates whether or not to supply
-                                    the --force flag to `kubectl apply`. The --force
-                                    flag deletes and re-create the resource, when
-                                    PATCH encounters conflict and has retried for
-                                    5 times.
-                                  type: boolean
-                              type: object
-                            hook:
-                              description: Hook will submit any referenced resources
-                                to perform the sync. This is the default strategy
-                              properties:
-                                force:
-                                  description: Force indicates whether or not to supply
-                                    the --force flag to `kubectl apply`. The --force
-                                    flag deletes and re-create the resource, when
-                                    PATCH encounters conflict and has retried for
-                                    5 times.
-                                  type: boolean
-                              type: object
-                          type: object
-                      type: object
-                  type: object
-                phase:
-                  description: Phase is the current phase of the operation
-                  type: string
-                startedAt:
-                  description: StartedAt contains time of operation start
-                  format: date-time
-                  type: string
-                syncResult:
-                  description: SyncResult is the result of a Sync operation
-                  properties:
-                    resources:
-                      description: Resources holds the sync result of each individual
-                        resource
-                      items:
-                        description: ResourceResult holds the operation result details
-                          of a specific resource
-                        properties:
-                          group:
-                            type: string
-                          hookPhase:
-                            description: 'the state of any operation associated with
-                              this resource OR hook note: can contain values for non-hook
-                              resources'
-                            type: string
-                          hookType:
-                            description: the type of the hook, empty for non-hook
-                              resources
-                            type: string
-                          kind:
-                            type: string
-                          message:
-                            description: message for the last sync OR operation
-                            type: string
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                          status:
-                            description: the final result of the sync, this is be
-                              empty if the resources is yet to be applied/pruned and
-                              is always zero-value for hooks
-                            type: string
-                          syncPhase:
-                            description: indicates the particular phase of the sync
-                              that this is for
-                            type: string
-                          version:
-                            type: string
-                        required:
-                        - group
-                        - kind
-                        - name
-                        - namespace
-                        - version
-                        type: object
-                      type: array
-                    revision:
-                      description: Revision holds the revision of the sync
+                  syncOptions:
+                    description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                    items:
                       type: string
-                    source:
-                      description: Source records the application source information
-                        of the sync, used for comparing auto-sync
-                      properties:
-                        chart:
-                          description: Chart is a Helm chart name
-                          type: string
-                        directory:
-                          description: Directory holds path/directory specific options
-                          properties:
-                            jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet
-                                specific options
-                              properties:
-                                extVars:
-                                  description: ExtVars is a list of Jsonnet External
-                                    Variables
-                                  items:
-                                    description: JsonnetVar is a jsonnet variable
-                                    properties:
-                                      code:
-                                        type: boolean
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                tlas:
-                                  description: TLAS is a list of Jsonnet Top-level
-                                    Arguments
-                                  items:
-                                    description: JsonnetVar is a jsonnet variable
-                                    properties:
-                                      code:
-                                        type: boolean
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                              type: object
-                            recurse:
-                              type: boolean
-                          type: object
-                        helm:
-                          description: Helm holds helm specific options
-                          properties:
-                            fileParameters:
-                              description: FileParameters are file parameters to the
-                                helm template
-                              items:
-                                description: HelmFileParameter is a file parameter
-                                  to a helm template
-                                properties:
-                                  name:
-                                    description: Name is the name of the helm parameter
-                                    type: string
-                                  path:
-                                    description: Path is the path value for the helm
-                                      parameter
-                                    type: string
-                                type: object
-                              type: array
-                            parameters:
-                              description: Parameters are parameters to the helm template
-                              items:
-                                description: HelmParameter is a parameter to a helm
-                                  template
-                                properties:
-                                  forceString:
-                                    description: ForceString determines whether to
-                                      tell Helm to interpret booleans and numbers
-                                      as strings
-                                    type: boolean
-                                  name:
-                                    description: Name is the name of the helm parameter
-                                    type: string
-                                  value:
-                                    description: Value is the value for the helm parameter
-                                    type: string
-                                type: object
-                              type: array
-                            releaseName:
-                              description: The Helm release name. If omitted it will
-                                use the application name
-                              type: string
-                            valueFiles:
-                              description: ValuesFiles is a list of Helm value files
-                                to use when generating a template
-                              items:
-                                type: string
-                              type: array
-                            values:
-                              description: Values is Helm values, typically defined
-                                as a block
-                              type: string
-                          type: object
-                        ksonnet:
-                          description: Ksonnet holds ksonnet specific options
-                          properties:
-                            environment:
-                              description: Environment is a ksonnet application environment
-                                name
-                              type: string
-                            parameters:
-                              description: Parameters are a list of ksonnet component
-                                parameter override values
-                              items:
-                                description: KsonnetParameter is a ksonnet component
-                                  parameter
-                                properties:
-                                  component:
-                                    type: string
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                          type: object
-                        kustomize:
-                          description: Kustomize holds kustomize specific options
-                          properties:
-                            commonLabels:
-                              additionalProperties:
-                                type: string
-                              description: CommonLabels adds additional kustomize
-                                commonLabels
-                              type: object
-                            images:
-                              description: Images are kustomize image overrides
-                              items:
-                                type: string
-                              type: array
-                            namePrefix:
-                              description: NamePrefix is a prefix appended to resources
-                                for kustomize apps
-                              type: string
-                            nameSuffix:
-                              description: NameSuffix is a suffix appended to resources
-                                for kustomize apps
-                              type: string
-                            version:
-                              description: Version contains optional Kustomize version
-                              type: string
-                          type: object
-                        path:
-                          description: Path is a directory path within the Git repository
-                          type: string
-                        plugin:
-                          description: ConfigManagementPlugin holds config management
-                            plugin specific options
-                          properties:
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    description: the name, usually uppercase
-                                    type: string
-                                  value:
-                                    description: the value
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                          type: object
-                        repoURL:
-                          description: RepoURL is the repository URL of the application
-                            manifests
-                          type: string
-                        targetRevision:
-                          description: TargetRevision defines the commit, tag, or
-                            branch in which to sync the application to. If omitted,
-                            will sync to HEAD
-                          type: string
-                      required:
-                      - repoURL
-                      type: object
-                  required:
-                  - revision
-                  type: object
-              required:
-              - operation
-              - phase
-              - startedAt
-              type: object
-            reconciledAt:
-              description: ReconciledAt indicates when the application state was reconciled
-                using the latest git version
-              format: date-time
-              type: string
-            resources:
-              items:
-                description: ResourceStatus holds the current sync and health status
-                  of a resource
-                properties:
-                  group:
-                    type: string
-                  health:
+                    type: array
+                  syncStrategy:
+                    description: SyncStrategy describes how to perform the sync
                     properties:
-                      message:
-                        type: string
-                      status:
-                        type: string
+                      apply:
+                        description: Apply will perform a `kubectl apply` to perform the sync.
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
+                      hook:
+                        description: Hook will submit any referenced resources to perform the sync. This is the default strategy
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
                     type: object
-                  hook:
-                    type: boolean
-                  kind:
-                    type: string
+                type: object
+            type: object
+          spec:
+            description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+            properties:
+              destination:
+                description: Destination is a reference to the target Kubernetes server and namespace
+                properties:
                   name:
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
                     type: string
                   namespace:
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
                     type: string
-                  requiresPruning:
-                    type: boolean
-                  status:
-                    description: SyncStatusCode is a type which represents possible
-                      comparison results
-                    type: string
-                  version:
+                  server:
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
                     type: string
                 type: object
-              type: array
-            sourceType:
-              type: string
-            summary:
-              properties:
-                externalURLs:
-                  description: ExternalURLs holds all external URLs of application
-                    child resources.
-                  items:
-                    type: string
-                  type: array
-                images:
-                  description: Images holds all images of application child resources.
-                  items:
-                    type: string
-                  type: array
-              type: object
-            sync:
-              description: SyncStatus is a comparison result of application spec and
-                deployed application.
-              properties:
-                comparedTo:
-                  description: ComparedTo contains application source and target which
-                    was used for resources comparison
+              ignoreDifferences:
+                description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
+                items:
+                  description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
                   properties:
-                    destination:
-                      description: ApplicationDestination contains deployment destination
-                        information
-                      properties:
-                        namespace:
-                          description: Namespace overrides the environment namespace
-                            value in the ksonnet app.yaml
+                    group:
+                      type: string
+                    jsonPointers:
+                      items:
+                        type: string
+                      type: array
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - jsonPointers
+                  - kind
+                  type: object
+                type: array
+              info:
+                description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              project:
+                description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
+                type: string
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                format: int64
+                type: integer
+              source:
+                description: Source is a reference to the location of the application's manifests or chart
+                properties:
+                  chart:
+                    description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                    type: string
+                  directory:
+                    description: Directory holds path/directory specific options
+                    properties:
+                      exclude:
+                        description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                        type: string
+                      include:
+                        description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                        type: string
+                      jsonnet:
+                        description: Jsonnet holds options specific to Jsonnet
+                        properties:
+                          extVars:
+                            description: ExtVars is a list of Jsonnet External Variables
+                            items:
+                              description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          libs:
+                            description: Additional library search dirs
+                            items:
+                              type: string
+                            type: array
+                          tlas:
+                            description: TLAS is a list of Jsonnet Top-level Arguments
+                            items:
+                              description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      recurse:
+                        description: Recurse specifies whether to scan a directory recursively for manifests
+                        type: boolean
+                    type: object
+                  helm:
+                    description: Helm holds helm specific options
+                    properties:
+                      fileParameters:
+                        description: FileParameters are file parameters to the helm template
+                        items:
+                          description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                          properties:
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            path:
+                              description: Path is the path to the file containing the values for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      parameters:
+                        description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                        items:
+                          description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                          properties:
+                            forceString:
+                              description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                              type: boolean
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            value:
+                              description: Value is the value for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      releaseName:
+                        description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                        type: string
+                      valueFiles:
+                        description: ValuesFiles is a list of Helm value files to use when generating a template
+                        items:
                           type: string
-                        server:
-                          description: Server overrides the environment server value
-                            in the ksonnet app.yaml
+                        type: array
+                      values:
+                        description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                        type: string
+                      version:
+                        description: Version is the Helm version to use for templating (either "2" or "3")
+                        type: string
+                    type: object
+                  ksonnet:
+                    description: Ksonnet holds ksonnet specific options
+                    properties:
+                      environment:
+                        description: Environment is a ksonnet application environment name
+                        type: string
+                      parameters:
+                        description: Parameters are a list of ksonnet component parameter override values
+                        items:
+                          description: KsonnetParameter is a ksonnet component parameter
+                          properties:
+                            component:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  kustomize:
+                    description: Kustomize holds kustomize specific options
+                    properties:
+                      commonAnnotations:
+                        additionalProperties:
                           type: string
-                      type: object
+                        description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                        type: object
+                      commonLabels:
+                        additionalProperties:
+                          type: string
+                        description: CommonLabels is a list of additional labels to add to rendered manifests
+                        type: object
+                      images:
+                        description: Images is a list of Kustomize image override specifications
+                        items:
+                          description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                          type: string
+                        type: array
+                      namePrefix:
+                        description: NamePrefix is a prefix appended to resources for Kustomize apps
+                        type: string
+                      nameSuffix:
+                        description: NameSuffix is a suffix appended to resources for Kustomize apps
+                        type: string
+                      version:
+                        description: Version controls which version of Kustomize to use for rendering manifests
+                        type: string
+                    type: object
+                  path:
+                    description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                    type: string
+                  plugin:
+                    description: ConfigManagementPlugin holds config management plugin specific options
+                    properties:
+                      env:
+                        description: Env is a list of environment variable entries
+                        items:
+                          description: EnvEntry represents an entry in the application's environment
+                          properties:
+                            name:
+                              description: Name is the name of the variable, usually expressed in uppercase
+                              type: string
+                            value:
+                              description: Value is the value of the variable
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                    type: object
+                  repoURL:
+                    description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                    type: string
+                  targetRevision:
+                    description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                    type: string
+                required:
+                - repoURL
+                type: object
+              syncPolicy:
+                description: SyncPolicy controls when and how a sync will be performed
+                properties:
+                  automated:
+                    description: Automated will keep an application synced to the target revision
+                    properties:
+                      allowEmpty:
+                        description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                        type: boolean
+                      prune:
+                        description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
+                        type: boolean
+                      selfHeal:
+                        description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
+                        type: boolean
+                    type: object
+                  retry:
+                    description: Retry controls failed sync retry behavior
+                    properties:
+                      backoff:
+                        description: Backoff controls how to backoff on subsequent retries of failed syncs
+                        properties:
+                          duration:
+                            description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                            type: string
+                          factor:
+                            description: Factor is a factor to multiply the base duration after each failed retry
+                            format: int64
+                            type: integer
+                          maxDuration:
+                            description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                            type: string
+                        type: object
+                      limit:
+                        description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                        format: int64
+                        type: integer
+                    type: object
+                  syncOptions:
+                    description: Options allow you to specify whole app sync-options
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - destination
+            - project
+            - source
+            type: object
+          status:
+            description: ApplicationStatus contains status information for the application
+            properties:
+              conditions:
+                description: Conditions is a list of currently observed application conditions
+                items:
+                  description: ApplicationCondition contains details about an application condition, which is usally an error or warning
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the time the condition was last observed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message contains human-readable message indicating details about condition
+                      type: string
+                    type:
+                      description: Type is an application condition type
+                      type: string
+                  required:
+                  - message
+                  - type
+                  type: object
+                type: array
+              health:
+                description: Health contains information about the application's current health status
+                properties:
+                  message:
+                    description: Message is a human-readable informational message describing the health status
+                    type: string
+                  status:
+                    description: Status holds the status code of the application or resource
+                    type: string
+                type: object
+              history:
+                description: History contains information about the application's sync history
+                items:
+                  description: RevisionHistory contains history information about a previous sync
+                  properties:
+                    deployStartedAt:
+                      description: DeployStartedAt holds the time the sync operation started
+                      format: date-time
+                      type: string
+                    deployedAt:
+                      description: DeployedAt holds the time the sync operation completed
+                      format: date-time
+                      type: string
+                    id:
+                      description: ID is an auto incrementing identifier of the RevisionHistory
+                      format: int64
+                      type: integer
+                    revision:
+                      description: Revision holds the revision the sync was performed against
+                      type: string
                     source:
-                      description: ApplicationSource contains information about github
-                        repository, path within repository and target application
-                        environment.
+                      description: Source is a reference to the application source used for the sync operation
                       properties:
                         chart:
-                          description: Chart is a Helm chart name
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
                           type: string
                         directory:
                           description: Directory holds path/directory specific options
                           properties:
+                            exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                              type: string
+                            include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                              type: string
                             jsonnet:
-                              description: ApplicationSourceJsonnet holds jsonnet
-                                specific options
+                              description: Jsonnet holds options specific to Jsonnet
                               properties:
                                 extVars:
-                                  description: ExtVars is a list of Jsonnet External
-                                    Variables
+                                  description: ExtVars is a list of Jsonnet External Variables
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1500,11 +729,15 @@ spec:
                                     - value
                                     type: object
                                   type: array
-                                tlas:
-                                  description: TLAS is a list of Jsonnet Top-level
-                                    Arguments
+                                libs:
+                                  description: Additional library search dirs
                                   items:
-                                    description: JsonnetVar is a jsonnet variable
+                                    type: string
+                                  type: array
+                                tlas:
+                                  description: TLAS is a list of Jsonnet Top-level Arguments
+                                  items:
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
                                     properties:
                                       code:
                                         type: boolean
@@ -1519,74 +752,66 @@ spec:
                                   type: array
                               type: object
                             recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
                               type: boolean
                           type: object
                         helm:
                           description: Helm holds helm specific options
                           properties:
                             fileParameters:
-                              description: FileParameters are file parameters to the
-                                helm template
+                              description: FileParameters are file parameters to the helm template
                               items:
-                                description: HelmFileParameter is a file parameter
-                                  to a helm template
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
                                 properties:
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   path:
-                                    description: Path is the path value for the helm
-                                      parameter
+                                    description: Path is the path to the file containing the values for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             parameters:
-                              description: Parameters are parameters to the helm template
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
                               items:
-                                description: HelmParameter is a parameter to a helm
-                                  template
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
                                 properties:
                                   forceString:
-                                    description: ForceString determines whether to
-                                      tell Helm to interpret booleans and numbers
-                                      as strings
+                                    description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
                                     type: boolean
                                   name:
-                                    description: Name is the name of the helm parameter
+                                    description: Name is the name of the Helm parameter
                                     type: string
                                   value:
-                                    description: Value is the value for the helm parameter
+                                    description: Value is the value for the Helm parameter
                                     type: string
                                 type: object
                               type: array
                             releaseName:
-                              description: The Helm release name. If omitted it will
-                                use the application name
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
                               type: string
                             valueFiles:
-                              description: ValuesFiles is a list of Helm value files
-                                to use when generating a template
+                              description: ValuesFiles is a list of Helm value files to use when generating a template
                               items:
                                 type: string
                               type: array
                             values:
-                              description: Values is Helm values, typically defined
-                                as a block
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                              type: string
+                            version:
+                              description: Version is the Helm version to use for templating (either "2" or "3")
                               type: string
                           type: object
                         ksonnet:
                           description: Ksonnet holds ksonnet specific options
                           properties:
                             environment:
-                              description: Environment is a ksonnet application environment
-                                name
+                              description: Environment is a ksonnet application environment name
                               type: string
                             parameters:
-                              description: Parameters are a list of ksonnet component
-                                parameter override values
+                              description: Parameters are a list of ksonnet component parameter override values
                               items:
-                                description: KsonnetParameter is a ksonnet component
-                                  parameter
+                                description: KsonnetParameter is a ksonnet component parameter
                                 properties:
                                   component:
                                     type: string
@@ -1603,44 +828,48 @@ spec:
                         kustomize:
                           description: Kustomize holds kustomize specific options
                           properties:
+                            commonAnnotations:
+                              additionalProperties:
+                                type: string
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                              type: object
                             commonLabels:
                               additionalProperties:
                                 type: string
-                              description: CommonLabels adds additional kustomize
-                                commonLabels
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
                               type: object
                             images:
-                              description: Images are kustomize image overrides
+                              description: Images is a list of Kustomize image override specifications
                               items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
                                 type: string
                               type: array
                             namePrefix:
-                              description: NamePrefix is a prefix appended to resources
-                                for kustomize apps
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
                               type: string
                             nameSuffix:
-                              description: NameSuffix is a suffix appended to resources
-                                for kustomize apps
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
                               type: string
                             version:
-                              description: Version contains optional Kustomize version
+                              description: Version controls which version of Kustomize to use for rendering manifests
                               type: string
                           type: object
                         path:
-                          description: Path is a directory path within the Git repository
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
                           type: string
                         plugin:
-                          description: ConfigManagementPlugin holds config management
-                            plugin specific options
+                          description: ConfigManagementPlugin holds config management plugin specific options
                           properties:
                             env:
+                              description: Env is a list of environment variable entries
                               items:
+                                description: EnvEntry represents an entry in the application's environment
                                 properties:
                                   name:
-                                    description: the name, usually uppercase
+                                    description: Name is the name of the variable, usually expressed in uppercase
                                     type: string
                                   value:
-                                    description: the value
+                                    description: Value is the value of the variable
                                     type: string
                                 required:
                                 - name
@@ -1651,37 +880,881 @@ spec:
                               type: string
                           type: object
                         repoURL:
-                          description: RepoURL is the repository URL of the application
-                            manifests
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
                           type: string
                         targetRevision:
-                          description: TargetRevision defines the commit, tag, or
-                            branch in which to sync the application to. If omitted,
-                            will sync to HEAD
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
                           type: string
                       required:
                       - repoURL
                       type: object
                   required:
-                  - destination
-                  - source
+                  - deployedAt
+                  - id
+                  - revision
                   type: object
-                revision:
-                  type: string
-                status:
-                  description: SyncStatusCode is a type which represents possible
-                    comparison results
-                  type: string
-              required:
-              - status
-              type: object
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                type: array
+              observedAt:
+                description: 'ObservedAt indicates when the application state was updated without querying latest git state Deprecated: controller no longer updates ObservedAt field'
+                format: date-time
+                type: string
+              operationState:
+                description: OperationState contains information about any ongoing operations, such as a sync
+                properties:
+                  finishedAt:
+                    description: FinishedAt contains time of operation completion
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message holds any pertinent messages when attempting to perform operation (typically errors).
+                    type: string
+                  operation:
+                    description: Operation is the original requested operation
+                    properties:
+                      info:
+                        description: Info is a list of informational items for this operation
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      initiatedBy:
+                        description: InitiatedBy contains information about who initiated the operations
+                        properties:
+                          automated:
+                            description: Automated is set to true if operation was initiated automatically by the application controller.
+                            type: boolean
+                          username:
+                            description: Username contains the name of a user who started operation
+                            type: string
+                        type: object
+                      retry:
+                        description: Retry controls the strategy to apply if a sync fails
+                        properties:
+                          backoff:
+                            description: Backoff controls how to backoff on subsequent retries of failed syncs
+                            properties:
+                              duration:
+                                description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                type: string
+                              factor:
+                                description: Factor is a factor to multiply the base duration after each failed retry
+                                format: int64
+                                type: integer
+                              maxDuration:
+                                description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                type: string
+                            type: object
+                          limit:
+                            description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                            format: int64
+                            type: integer
+                        type: object
+                      sync:
+                        description: Sync contains parameters for the operation
+                        properties:
+                          dryRun:
+                            description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+                            type: boolean
+                          manifests:
+                            description: Manifests is an optional field that overrides sync source with a local directory for development
+                            items:
+                              type: string
+                            type: array
+                          prune:
+                            description: Prune specifies to delete resources from the cluster that are no longer tracked in git
+                            type: boolean
+                          resources:
+                            description: Resources describes which resources shall be part of the sync
+                            items:
+                              description: SyncOperationResource contains resources to sync.
+                              properties:
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            type: array
+                          revision:
+                            description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
+                            type: string
+                          source:
+                            description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
+                            properties:
+                              chart:
+                                description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                                type: string
+                              directory:
+                                description: Directory holds path/directory specific options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm holds helm specific options
+                                properties:
+                                  fileParameters:
+                                    description: FileParameters are file parameters to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                    type: string
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                    type: string
+                                  version:
+                                    description: Version is the Helm version to use for templating (either "2" or "3")
+                                    type: string
+                                type: object
+                              ksonnet:
+                                description: Ksonnet holds ksonnet specific options
+                                properties:
+                                  environment:
+                                    description: Environment is a ksonnet application environment name
+                                    type: string
+                                  parameters:
+                                    description: Parameters are a list of ksonnet component parameter override values
+                                    items:
+                                      description: KsonnetParameter is a ksonnet component parameter
+                                      properties:
+                                        component:
+                                          type: string
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              kustomize:
+                                description: Kustomize holds kustomize specific options
+                                properties:
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                    type: object
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional labels to add to rendered manifests
+                                    type: object
+                                  images:
+                                    description: Images is a list of Kustomize image override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                    type: string
+                                  version:
+                                    description: Version controls which version of Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
+                              path:
+                                description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                                type: string
+                              plugin:
+                                description: ConfigManagementPlugin holds config management plugin specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable entries
+                                    items:
+                                      description: EnvEntry represents an entry in the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable, usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                type: object
+                              repoURL:
+                                description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                                type: string
+                              targetRevision:
+                                description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                                type: string
+                            required:
+                            - repoURL
+                            type: object
+                          syncOptions:
+                            description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                            items:
+                              type: string
+                            type: array
+                          syncStrategy:
+                            description: SyncStrategy describes how to perform the sync
+                            properties:
+                              apply:
+                                description: Apply will perform a `kubectl apply` to perform the sync.
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                                    type: boolean
+                                type: object
+                              hook:
+                                description: Hook will submit any referenced resources to perform the sync. This is the default strategy
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  phase:
+                    description: Phase is the current phase of the operation
+                    type: string
+                  retryCount:
+                    description: RetryCount contains time of operation retries
+                    format: int64
+                    type: integer
+                  startedAt:
+                    description: StartedAt contains time of operation start
+                    format: date-time
+                    type: string
+                  syncResult:
+                    description: SyncResult is the result of a Sync operation
+                    properties:
+                      resources:
+                        description: Resources contains a list of sync result items for each individual resource in a sync operation
+                        items:
+                          description: ResourceResult holds the operation result details of a specific resource
+                          properties:
+                            group:
+                              description: Group specifies the API group of the resource
+                              type: string
+                            hookPhase:
+                              description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
+                              type: string
+                            hookType:
+                              description: HookType specifies the type of the hook. Empty for non-hook resources
+                              type: string
+                            kind:
+                              description: Kind specifies the API kind of the resource
+                              type: string
+                            message:
+                              description: Message contains an informational or error message for the last sync OR operation
+                              type: string
+                            name:
+                              description: Name specifies the name of the resource
+                              type: string
+                            namespace:
+                              description: Namespace specifies the target namespace of the resource
+                              type: string
+                            status:
+                              description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                              type: string
+                            syncPhase:
+                              description: SyncPhase indicates the particular phase of the sync that this result was acquired in
+                              type: string
+                            version:
+                              description: Version specifies the API version of the resource
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          - namespace
+                          - version
+                          type: object
+                        type: array
+                      revision:
+                        description: Revision holds the revision this sync operation was performed to
+                        type: string
+                      source:
+                        description: Source records the application source information of the sync, used for comparing auto-sync
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating (either "2" or "3")
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional labels to add to rendered manifests
+                                type: object
+                              images:
+                                description: Images is a list of Kustomize image override specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable entries
+                                items:
+                                  description: EnvEntry represents an entry in the application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable, usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - revision
+                    type: object
+                required:
+                - operation
+                - phase
+                - startedAt
+                type: object
+              reconciledAt:
+                description: ReconciledAt indicates when the application state was reconciled using the latest git version
+                format: date-time
+                type: string
+              resources:
+                description: Resources is a list of Kubernetes resources managed by this application
+                items:
+                  description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      description: HealthStatus contains information about the currently observed health state of an application or resource
+                      properties:
+                        message:
+                          description: Message is a human-readable informational message describing the health status
+                          type: string
+                        status:
+                          description: Status holds the status code of the application or resource
+                          type: string
+                      type: object
+                    hook:
+                      type: boolean
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    requiresPruning:
+                      type: boolean
+                    status:
+                      description: SyncStatusCode is a type which represents possible comparison results
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+              sourceType:
+                description: SourceType specifies the type of this application
+                type: string
+              summary:
+                description: Summary contains a list of URLs and container images used by this application
+                properties:
+                  externalURLs:
+                    description: ExternalURLs holds all external URLs of application child resources.
+                    items:
+                      type: string
+                    type: array
+                  images:
+                    description: Images holds all images of application child resources.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              sync:
+                description: Sync contains information about the application's current sync status
+                properties:
+                  comparedTo:
+                    description: ComparedTo contains information about what has been compared
+                    properties:
+                      destination:
+                        description: Destination is a reference to the application's destination used for comparison
+                        properties:
+                          name:
+                            description: Name is an alternate way of specifying the target cluster by its symbolic name
+                            type: string
+                          namespace:
+                            description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                            type: string
+                          server:
+                            description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                            type: string
+                        type: object
+                      source:
+                        description: Source is a reference to the application's source used for comparison
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating (either "2" or "3")
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional labels to add to rendered manifests
+                                type: object
+                              images:
+                                description: Images is a list of Kustomize image override specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable entries
+                                items:
+                                  description: EnvEntry represents an entry in the application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable, usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - destination
+                    - source
+                    type: object
+                  revision:
+                    description: Revision contains information about the revision the comparison has been performed to
+                    type: string
+                  status:
+                    description: Status is the sync state of the comparison
+                    type: string
+                required:
+                - status
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}

--- a/kubernetes/argocd/appproject-crd.yaml
+++ b/kubernetes/argocd/appproject-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
@@ -16,211 +16,242 @@ spec:
     - appprojs
     singular: appproject
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: 'AppProject provides a logical grouping of applications, providing
-        controls for: * where the apps may deploy to (cluster whitelist) * what may
-        be deployed (repository whitelist, resource whitelist/blacklist) * who can
-        access these applications (roles, OIDC group claims bindings) * and what they
-        can do (RBAC policies) * automation access to these roles (JWT tokens)'
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AppProjectSpec is the specification of an AppProject
-          properties:
-            clusterResourceWhitelist:
-              description: ClusterResourceWhitelist contains list of whitelisted cluster
-                level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not
-                  force a version.  This is useful for identifying concepts during
-                  lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            description:
-              description: Description contains optional project description
-              type: string
-            destinations:
-              description: Destinations contains list of destinations available for
-                deployment
-              items:
-                description: ApplicationDestination contains deployment destination
-                  information
-                properties:
-                  namespace:
-                    description: Namespace overrides the environment namespace value
-                      in the ksonnet app.yaml
-                    type: string
-                  server:
-                    description: Server overrides the environment server value in
-                      the ksonnet app.yaml
-                    type: string
-                type: object
-              type: array
-            namespaceResourceBlacklist:
-              description: NamespaceResourceBlacklist contains list of blacklisted
-                namespace level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not
-                  force a version.  This is useful for identifying concepts during
-                  lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            namespaceResourceWhitelist:
-              description: NamespaceResourceWhitelist contains list of whitelisted
-                namespace level resources
-              items:
-                description: GroupKind specifies a Group and a Kind, but does not
-                  force a version.  This is useful for identifying concepts during
-                  lookup stages without having partially valid types
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                required:
-                - group
-                - kind
-                type: object
-              type: array
-            orphanedResources:
-              description: OrphanedResources specifies if controller should monitor
-                orphaned resources of apps in this project
-              properties:
-                warn:
-                  description: Warn indicates if warning condition should be created
-                    for apps which have orphaned resources
-                  type: boolean
-              type: object
-            roles:
-              description: Roles are user defined RBAC roles associated with this
-                project
-              items:
-                description: ProjectRole represents a role that has access to a project
-                properties:
-                  description:
-                    description: Description is a description of the role
-                    type: string
-                  groups:
-                    description: Groups are a list of OIDC group claims bound to this
-                      role
-                    items:
-                      type: string
-                    type: array
-                  jwtTokens:
-                    description: JWTTokens are a list of generated JWT tokens bound
-                      to this role
-                    items:
-                      description: JWTToken holds the issuedAt and expiresAt values
-                        of a token
-                      properties:
-                        exp:
-                          format: int64
-                          type: integer
-                        iat:
-                          format: int64
-                          type: integer
-                        id:
-                          type: string
-                      required:
-                      - iat
-                      type: object
-                    type: array
-                  name:
-                    description: Name is a name for this role
-                    type: string
-                  policies:
-                    description: Policies Stores a list of casbin formated strings
-                      that define access policies for the role in the project
-                    items:
-                      type: string
-                    type: array
-                required:
-                - name
-                type: object
-              type: array
-            sourceRepos:
-              description: SourceRepos contains list of repository URLs which can
-                be used for deployment
-              items:
-                type: string
-              type: array
-            syncWindows:
-              description: SyncWindows controls when syncs can be run for apps in
-                this project
-              items:
-                description: SyncWindow contains the kind, time, duration and attributes
-                  that are used to assign the syncWindows to apps
-                properties:
-                  applications:
-                    description: Applications contains a list of applications that
-                      the window will apply to
-                    items:
-                      type: string
-                    type: array
-                  clusters:
-                    description: Clusters contains a list of clusters that the window
-                      will apply to
-                    items:
-                      type: string
-                    type: array
-                  duration:
-                    description: Duration is the amount of time the sync window will
-                      be open
-                    type: string
-                  kind:
-                    description: Kind defines if the window allows or blocks syncs
-                    type: string
-                  manualSync:
-                    description: ManualSync enables manual syncs when they would otherwise
-                      be blocked
-                    type: boolean
-                  namespaces:
-                    description: Namespaces contains a list of namespaces that the
-                      window will apply to
-                    items:
-                      type: string
-                    type: array
-                  schedule:
-                    description: Schedule is the time the window will begin, specified
-                      in cron format
-                    type: string
-                type: object
-              type: array
-          type: object
-      required:
-      - metadata
-      - spec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'AppProject provides a logical grouping of applications, providing controls for: * where the apps may deploy to (cluster whitelist) * what may be deployed (repository whitelist, resource whitelist/blacklist) * who can access these applications (roles, OIDC group claims bindings) * and what they can do (RBAC policies) * automation access to these roles (JWT tokens)'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AppProjectSpec is the specification of an AppProject
+            properties:
+              clusterResourceBlacklist:
+                description: ClusterResourceBlacklist contains list of blacklisted cluster level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              clusterResourceWhitelist:
+                description: ClusterResourceWhitelist contains list of whitelisted cluster level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              description:
+                description: Description contains optional project description
+                type: string
+              destinations:
+                description: Destinations contains list of destinations available for deployment
+                items:
+                  description: ApplicationDestination holds information about the application's destination
+                  properties:
+                    name:
+                      description: Name is an alternate way of specifying the target cluster by its symbolic name
+                      type: string
+                    namespace:
+                      description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                      type: string
+                    server:
+                      description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                      type: string
+                  type: object
+                type: array
+              namespaceResourceBlacklist:
+                description: NamespaceResourceBlacklist contains list of blacklisted namespace level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              namespaceResourceWhitelist:
+                description: NamespaceResourceWhitelist contains list of whitelisted namespace level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              orphanedResources:
+                description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
+                properties:
+                  ignore:
+                    description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
+                    items:
+                      description: OrphanedResourceKey is a reference to a resource to be ignored from
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  warn:
+                    description: Warn indicates if warning condition should be created for apps which have orphaned resources
+                    type: boolean
+                type: object
+              roles:
+                description: Roles are user defined RBAC roles associated with this project
+                items:
+                  description: ProjectRole represents a role that has access to a project
+                  properties:
+                    description:
+                      description: Description is a description of the role
+                      type: string
+                    groups:
+                      description: Groups are a list of OIDC group claims bound to this role
+                      items:
+                        type: string
+                      type: array
+                    jwtTokens:
+                      description: JWTTokens are a list of generated JWT tokens bound to this role
+                      items:
+                        description: JWTToken holds the issuedAt and expiresAt values of a token
+                        properties:
+                          exp:
+                            format: int64
+                            type: integer
+                          iat:
+                            format: int64
+                            type: integer
+                          id:
+                            type: string
+                        required:
+                        - iat
+                        type: object
+                      type: array
+                    name:
+                      description: Name is a name for this role
+                      type: string
+                    policies:
+                      description: Policies Stores a list of casbin formated strings that define access policies for the role in the project
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              signatureKeys:
+                description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
+                items:
+                  description: SignatureKey is the specification of a key required to verify commit signatures with
+                  properties:
+                    keyID:
+                      description: The ID of the key in hexadecimal notation
+                      type: string
+                  required:
+                  - keyID
+                  type: object
+                type: array
+              sourceRepos:
+                description: SourceRepos contains list of repository URLs which can be used for deployment
+                items:
+                  type: string
+                type: array
+              syncWindows:
+                description: SyncWindows controls when syncs can be run for apps in this project
+                items:
+                  description: SyncWindow contains the kind, time, duration and attributes that are used to assign the syncWindows to apps
+                  properties:
+                    applications:
+                      description: Applications contains a list of applications that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    clusters:
+                      description: Clusters contains a list of clusters that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    duration:
+                      description: Duration is the amount of time the sync window will be open
+                      type: string
+                    kind:
+                      description: Kind defines if the window allows or blocks syncs
+                      type: string
+                    manualSync:
+                      description: ManualSync enables manual syncs when they would otherwise be blocked
+                      type: boolean
+                    namespaces:
+                      description: Namespaces contains a list of namespaces that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    schedule:
+                      description: Schedule is the time the window will begin, specified in cron format
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: AppProjectStatus contains status information for AppProject CRs
+            properties:
+              jwtTokensByRole:
+                additionalProperties:
+                  description: JWTTokens represents a list of JWT tokens
+                  properties:
+                    items:
+                      items:
+                        description: JWTToken holds the issuedAt and expiresAt values of a token
+                        properties:
+                          exp:
+                            format: int64
+                            type: integer
+                          iat:
+                            format: int64
+                            type: integer
+                          id:
+                            type: string
+                        required:
+                        - iat
+                        type: object
+                      type: array
+                  type: object
+                description: JWTTokensByRole contains a list of JWT tokens issued for a given role
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true

--- a/kubernetes/argocd/install.yaml
+++ b/kubernetes/argocd/install.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,6 +15,15 @@ metadata:
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
   name: argocd-dex-server
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -83,6 +91,24 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -214,6 +240,22 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-redis
+subjects:
+- kind: ServiceAccount
+  name: argocd-redis
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
@@ -267,6 +309,14 @@ metadata:
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
   name: argocd-cm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-gpg-keys-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-gpg-keys-cm
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -395,23 +445,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: argocd-server-metrics
-    app.kubernetes.io/part-of: argocd
-  name: argocd-server-metrics
-spec:
-  ports:
-  - name: metrics
-    port: 8083
-    protocol: TCP
-    targetPort: 8083
-  selector:
-    app.kubernetes.io/name: argocd-server
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
   name: argocd-server
@@ -428,50 +461,22 @@ spec:
   selector:
     app.kubernetes.io/name: argocd-server
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: application-controller
-    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server-metrics
     app.kubernetes.io/part-of: argocd
-  name: argocd-application-controller
+  name: argocd-server-metrics
 spec:
+  ports:
+  - name: metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
   selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-application-controller
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: argocd-application-controller
-    spec:
-      containers:
-      - command:
-        - argocd-application-controller
-        - --status-processors
-        - "20"
-        - --operation-processors
-        - "10"
-        image: argoproj/argocd:v1.5.3
-        imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        name: argocd-application-controller
-        ports:
-        - containerPort: 8082
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8082
-          initialDelaySeconds: 5
-          periodSeconds: 10
-      serviceAccountName: argocd-application-controller
+    app.kubernetes.io/name: argocd-server
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -490,11 +495,20 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-dex-server
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       containers:
       - command:
-        - /shared/argocd-util
+        - /shared/argocd-dex
         - rundex
-        image: quay.io/dexidp/dex:v2.22.0
+        image: ghcr.io/dexidp/dex:v2.27.0
         imagePullPolicy: Always
         name: dex
         ports:
@@ -508,9 +522,9 @@ spec:
       - command:
         - cp
         - -n
-        - /usr/local/bin/argocd-util
-        - /shared
-        image: argoproj/argocd:v1.5.3
+        - /usr/local/bin/argocd
+        - /shared/argocd-dex
+        image: quay.io/argoproj/argocd:v2.0.5
         imagePullPolicy: Always
         name: copyutil
         volumeMounts:
@@ -520,52 +534,7 @@ spec:
       volumes:
       - emptyDir: {}
         name: static-files
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  labels:
-    app.kubernetes.io/component: redis
-    app.kubernetes.io/name: argocd-redis
-    app.kubernetes.io/part-of: argocd
-  name: argocd-redis
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: argocd-redis
-  serviceName: argocd-redis
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: argocd-redis
-    spec:
-      terminationGracePeriodSeconds: 10
-      containers:
-      - name: redis
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "100m" # equivalent to 0.1 of a CPU core
-        args:
-        - --save
-        - "60 1000"
-        - --appendonly
-        - "yes"
-        image: redis:5.0.8
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 6379
-        volumeMounts:
-        - name: redis-data
-          mountPath: /data
-  volumeClaimTemplates:
-  - metadata:
-      name: redis-data
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 10Gi
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -584,6 +553,21 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-repo-server
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-repo-server
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       automountServiceAccountToken: false
       containers:
       - command:
@@ -591,27 +575,41 @@ spec:
         - argocd-repo-server
         - --redis
         - argocd-redis:6379
-        image: argoproj/argocd:v1.5.3
+        image: quay.io/argoproj/argocd:v2.0.5
         imagePullPolicy: Always
         livenessProbe:
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 8081
+          failureThreshold: 3
+          httpGet:
+            path: /healthz?full=true
+            port: 8084
+          initialDelaySeconds: 30
+          periodSeconds: 5
         name: argocd-repo-server
         ports:
         - containerPort: 8081
         - containerPort: 8084
         readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8084
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8081
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
         - mountPath: /app/config/tls
           name: tls-certs
+        - mountPath: /app/config/gpg/source
+          name: gpg-keys
+        - mountPath: /app/config/gpg/keys
+          name: gpg-keyring
+        - mountPath: /app/config/reposerver/tls
+          name: argocd-repo-server-tls
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm
@@ -619,6 +617,22 @@ spec:
       - configMap:
           name: argocd-tls-certs-cm
         name: tls-certs
+      - configMap:
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
+      - name: argocd-repo-server-tls
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: ca.crt
+            path: ca.crt
+          optional: true
+          secretName: argocd-repo-server-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -637,16 +651,31 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-server
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-server
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
       containers:
       - command:
         - argocd-server
         - --staticassets
         - /shared/app
-        image: argoproj/argocd:v1.5.3
+        image: quay.io/argoproj/argocd:v2.0.5
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz?full=true
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 30
@@ -660,11 +689,18 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
         - mountPath: /app/config/tls
           name: tls-certs
+        - mountPath: /app/config/server/tls
+          name: argocd-repo-server-tls
       serviceAccountName: argocd-server
       volumes:
       - emptyDir: {}
@@ -675,3 +711,203 @@ spec:
       - configMap:
           name: argocd-tls-certs-cm
         name: tls-certs
+      - name: argocd-repo-server-tls
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: ca.crt
+            path: ca.crt
+          optional: true
+          secretName: argocd-repo-server-tls
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-application-controller
+  serviceName: argocd-application-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-application-controller
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: argocd-application-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/part-of: argocd
+              topologyKey: kubernetes.io/hostname
+            weight: 5
+      containers:
+      - command:
+        - argocd-application-controller
+        - --status-processors
+        - "20"
+        - --operation-processors
+        - "10"
+        image: quay.io/argoproj/argocd:v2.0.5
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        name: argocd-application-controller
+        ports:
+        - containerPort: 8082
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+        volumeMounts:
+        - mountPath: /app/config/controller/tls
+          name: argocd-repo-server-tls
+      serviceAccountName: argocd-application-controller
+      volumes:
+      - name: argocd-repo-server-tls
+        secret:
+          items:
+          - key: tls.crt
+            path: tls.crt
+          - key: tls.key
+            path: tls.key
+          - key: ca.crt
+            path: ca.crt
+          optional: true
+          secretName: argocd-repo-server-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-application-controller-network-policy
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8082
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-application-controller
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-dex-server-network-policy
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-server
+    ports:
+    - port: 5556
+      protocol: TCP
+    - port: 5557
+      protocol: TCP
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 5558
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-dex-server
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-redis-network-policy
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-server
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-repo-server
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-application-controller
+    ports:
+    - port: 6379
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-repo-server-network-policy
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-server
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-application-controller
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: argocd-notifications-controller
+    ports:
+    - port: 8081
+      protocol: TCP
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 8084
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-server-network-policy
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  policyTypes:
+  - Ingress

--- a/kubernetes/argocd/redis-persistent.yaml
+++ b/kubernetes/argocd/redis-persistent.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis
+    app.kubernetes.io/part-of: argocd
+  name: argocd-redis
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis
+  serviceName: argocd-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: argocd-redis
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: redis
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "100m" # equivalent to 0.1 of a CPU core
+        args:
+        - --save
+        - "60 1000"
+        - --appendonly
+        - "yes"
+        image: redis:6.2.4-alpine
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: argocd-redis
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes/eksctl/max-pods-calculator.sh
+++ b/kubernetes/eksctl/max-pods-calculator.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+set -o pipefail
+set -o nounset
+set -o errexit
+
+err_report() {
+    echo "Exited with error on line $1"
+}
+trap 'err_report $LINENO' ERR
+
+function print_help {
+    echo "usage: $0 <instance(s)> [options]"
+    echo "Calculates maxPods value to be used when starting up the kubelet."
+    echo "-h,--help print this help."
+    echo "--instance-type Specify the instance type to calculate max pods value."
+    echo "--instance-type-from-imds Use this flag if the instance type should be fetched from IMDS."
+    echo "--cni-version Specify the version of the CNI (example - 1.7.5)."
+    echo "--cni-custom-networking-enabled Use this flag to indicate if CNI custom networking mode has been enabled."
+    echo "--cni-prefix-delegation-enabled Use this flag to indicate if CNI prefix delegation has been enabled."
+    echo "--cni-max-eni specify how many ENIs should be used for prefix delegation. Defaults to using all ENIs per instance."
+}
+
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -h|--help)
+            print_help
+            exit 1
+            ;;
+        --instance-type)
+            INSTANCE_TYPE=$2
+            shift
+            shift
+            ;;
+        --instance-type-from-imds)
+            INSTANCE_TYPE_FROM_IMDS=true
+            shift
+            ;;
+        --cni-version)
+            CNI_VERSION=$2
+            shift
+            shift
+            ;;
+        --cni-custom-networking-enabled)
+            CNI_CUSTOM_NETWORKING_ENABLED=true
+            shift
+            ;;
+        --cni-prefix-delegation-enabled)
+            CNI_PREFIX_DELEGATION_ENABLED=true
+            shift
+            ;;
+        --cni-max-eni)
+            CNI_MAX_ENI=$2
+            shift
+            shift
+            ;;
+        *)    # unknown option
+            POSITIONAL+=("$1") # save it in an array for later
+            shift # past argument
+            ;;
+    esac
+done
+
+CNI_VERSION="${CNI_VERSION:-}"
+CNI_CUSTOM_NETWORKING_ENABLED="${CNI_CUSTOM_NETWORKING_ENABLED:-false}"
+CNI_PREFIX_DELEGATION_ENABLED="${CNI_PREFIX_DELEGATION_ENABLED:-false}"
+CNI_MAX_ENI="${CNI_MAX_ENI:-}"
+INSTANCE_TYPE="${INSTANCE_TYPE:-}"
+INSTANCE_TYPE_FROM_IMDS="${INSTANCE_TYPE_FROM_IMDS:-false}"
+
+PREFIX_DELEGATION_SUPPORTED=false
+IPS_PER_PREFIX=16
+
+if [ "$INSTANCE_TYPE_FROM_IMDS" = true ]; then
+    TOKEN=$(curl -m 10 -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 600" -s "http://169.254.169.254/latest/api/token")
+    export AWS_DEFAULT_REGION=$(curl -s --retry 5 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+    INSTANCE_TYPE=$(curl -m 10 -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-type)
+elif [ -z "$INSTANCE_TYPE" ];
+    # There's no reasonable default for an instanceType so force one to be provided to the script.
+    then echo "You must specify an instance type to calculate max pods value."
+    exit 1
+fi
+
+if [ -z "$CNI_VERSION" ];
+    then echo "You must specify a CNI Version to use. Example - 1.7.5"
+    exit 1
+fi
+
+calculate_max_ip_addresses_prefix_delegation() {
+    enis=$1
+    instance_max_eni_ips=$2
+    echo $(($enis * (($instance_max_eni_ips - 1) * $IPS_PER_PREFIX ) + 2))
+}
+
+calculate_max_ip_addresses_secondary_ips() {
+    enis=$1
+    instance_max_eni_ips=$2
+    echo $(($enis * ($instance_max_eni_ips - 1) + 2))
+}
+
+min_number() {
+    printf "%s\n" "$@" | sort -g | head -n1
+}
+
+
+VERSION_SPLIT=(${CNI_VERSION//./ })
+CNI_MAJOR_VERSION="${VERSION_SPLIT[0]}"
+CNI_MINOR_VERSION="${VERSION_SPLIT[1]}"
+if [[ "$CNI_MAJOR_VERSION" -gt 1 ]] || ([[ "$CNI_MAJOR_VERSION" = 1 ]] && [[ "$CNI_MINOR_VERSION" -gt 8 ]]); then
+    PREFIX_DELEGATION_SUPPORTED=true
+fi
+
+DESCRIBE_INSTANCES_RESULT=$(aws ec2 describe-instance-types --instance-type $INSTANCE_TYPE --query 'InstanceTypes[0].{Hypervisor: Hypervisor, EniCount: NetworkInfo.MaximumNetworkInterfaces, PodsPerEniCount: NetworkInfo.Ipv4AddressesPerInterface, CpuCount: VCpuInfo.DefaultVCpus'})
+
+HYPERVISOR_TYPE=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.Hypervisor' )
+IS_NITRO=false
+if [[ "$HYPERVISOR_TYPE" == "nitro" ]]; then
+    IS_NITRO=true
+fi
+INSTANCE_MAX_ENIS=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.EniCount' )
+INSTANCE_MAX_ENIS_IPS=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.PodsPerEniCount' )
+
+if [ -z "$CNI_MAX_ENI" ] ; then
+    enis_for_pods=$INSTANCE_MAX_ENIS
+else
+    enis_for_pods="$(min_number $CNI_MAX_ENI $INSTANCE_MAX_ENIS)"
+fi
+
+if [ "$CNI_CUSTOM_NETWORKING_ENABLED" = true ] ; then
+    enis_for_pods=$((enis_for_pods-1))
+fi
+
+
+if [ "$IS_NITRO" = true ] && [ "$CNI_PREFIX_DELEGATION_ENABLED" = true ] && [ "$PREFIX_DELEGATION_SUPPORTED" = true ]; then
+    max_pods=$(calculate_max_ip_addresses_prefix_delegation $enis_for_pods $INSTANCE_MAX_ENIS_IPS)
+else
+    max_pods=$(calculate_max_ip_addresses_secondary_ips $enis_for_pods $INSTANCE_MAX_ENIS_IPS)
+fi
+
+# Limit the total number of pods that can be launched on any instance type based on the vCPUs on that instance type.
+MAX_POD_CEILING_FOR_LOW_CPU=110
+MAX_POD_CEILING_FOR_HIGH_CPU=250
+CPU_COUNT=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.CpuCount' )
+if [ "$CPU_COUNT" -gt 30 ] ; then
+    echo $(min_number $MAX_POD_CEILING_FOR_HIGH_CPU $max_pods)
+else
+    echo $(min_number $MAX_POD_CEILING_FOR_LOW_CPU $max_pods)
+fi

--- a/kubernetes/eksctl/operationcode-backend.yaml
+++ b/kubernetes/eksctl/operationcode-backend.yaml
@@ -6,25 +6,27 @@ metadata:
   name: operationcode-backend
   region: us-east-2
 
-nodeGroups:
-  - name: eks-infra-spot
+managedNodeGroups:
+  - name: eks-infra-spot-v2
+    instanceTypes:
+    - t3.small
+    spot: true
     minSize: 3
     desiredCapacity: 3
     maxSize: 5
-    # use Spot instance pricing
-    instancesDistribution:
-      instanceTypes:
-      - t3.small
-      onDemandBaseCapacity: 0
-      onDemandPercentageAboveBaseCapacity: 0
     volumeSize: 20
+    volumeType: gp3
+    # For this to be valid, run:
+    #   kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true
+    #   kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1
+    maxPodsPerNode: 30
     ssh:
       allow: true
       publicKeyName: oc-ops
     labels:
       nodegroup-type: infra
     tags:
-      Name: eks-infra-spot
+      Name: eks-infra-spot-v2
     iam:
       withAddonPolicies:
         imageBuilder: true

--- a/kubernetes/operationcode_python_backend/base/deployment.yaml
+++ b/kubernetes/operationcode_python_backend/base/deployment.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: "autoscaling.k8s.io/v1beta2"
-kind: VerticalPodAutoscaler
-metadata:
-  name: back-end-vpa
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: back-end
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/prod/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/actions.response-401: '{"Type":"fixed-response","FixedResponseConfig":{"ContentType":"text/plain","StatusCode":"401","MessageBody":"401 Not Authorized"}}'
+    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=oc-alb-logs,access_logs.s3.prefix=oc-prod
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=600
   labels:
     app: back-end
 spec:

--- a/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-2-2017-01
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/actions.response-401: '{"Type":"fixed-response","FixedResponseConfig":{"ContentType":"text/plain","StatusCode":"401","MessageBody":"401 Not Authorized"}}'
+    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=oc-alb-logs,access_logs.s3.prefix=oc-staging
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=600
   labels:
     app: back-end
 spec:

--- a/kubernetes/resources_api/base/deployment.yaml
+++ b/kubernetes/resources_api/base/deployment.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: "autoscaling.k8s.io/v1beta2"
-kind: VerticalPodAutoscaler
-metadata:
-  name: resources-api-vpa
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: resources-api
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/town_crier/base/deployment.yaml
+++ b/kubernetes/town_crier/base/deployment.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: "autoscaling.k8s.io/v1beta2"
-kind: VerticalPodAutoscaler
-metadata:
-  name: town-crier-vpa
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: town-crier
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This PR is purely to sync our codebase with reality.  These updates are already tested and deployed out to our cluster.  

* Upgrade our EKS cluster to 1.20 and switch to a Managed Node Group
  * This lets us take advantage of higher pod:node ratios due to networking advances
* Add S3-based logging to our ALBs so we can better catch errors when they alarm
* Upgrade ArgoCD to the latest, 2.0.5
* Clean up Vertical Pod Autoscalers (VPAs) since we don't use them anymore

Signed-off-by: Irving Popovetsky <irving@honeycomb.io>