### PR TITLE
Update location of staging database

### DIFF
--- a/kubernetes/operationcode_python_backend/overlays/staging/deployment.yaml
+++ b/kubernetes/operationcode_python_backend/overlays/staging/deployment.yaml
@@ -10,7 +10,7 @@ spec:
           image: operationcode/back-end:staging
           env:
             - name: DB_HOST
-              value: python-staging.czwauqf3tjaz.us-east-2.rds.amazonaws.com
+              value: postgres.pgo.svc.cluster.local
             - name: ENVIRONMENT
               value: aws_staging
             - name: EXTRA_HOSTS

--- a/kubernetes/resources_api/overlays/staging/database-service.yaml
+++ b/kubernetes/resources_api/overlays/staging/database-service.yaml
@@ -4,4 +4,4 @@ metadata:
   name: resources-postgres
 spec:
   type: ExternalName
-  externalName: python-staging.czwauqf3tjaz.us-east-2.rds.amazonaws.com
+  externalName: staging-postgres.pgo.svc.cluster.local


### PR DESCRIPTION
@kylemh alerted me to failing Cypress tests. Turns out the staging database is gone and replaced with a different db. Once this is merged, I'll run the migrations and populate the db with data from prod and then the tests relying on staging should pass again.