### PR TITLE
Port python services (backend, resources_api & pybot) to ECS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,10 @@ workflows:
       - terraform/fmt:
           checkout: true
           context: terraform
+          path: terraform
       - terraform/validate:
           checkout: true
           context: terraform
+          path: terraform
           requires:
             - terraform/fmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,77 +1,14 @@
-version: 2
-jobs:
-  validate:
-    docker:
-      - image: hashicorp/terraform:0.11.14
-
-    steps:
-      - checkout
-
-      - run:
-          command: |
-            mkdir bin
-            curl -sSL https://github.com/gruntwork-io/terragrunt/releases/download/v0.18.3/terragrunt_linux_amd64 -o bin/terragrunt
-            chmod +x bin/terragrunt
-
-      - run:
-          command: |
-            cd dns/operationcode.net/
-            /root/project/bin/terragrunt validate
-
-      - save_cache:
-          key: terragrunt
-          paths:
-            - bin/terragrunt
-
-  plan:
-    docker:
-      - image: hashicorp/terraform:0.11.14
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: terragrunt
-          paths:
-            - bin/terragrunt
-
-      - run:
-          name: terraform plan
-          command: |
-            /root/project/bin/terragrunt plan-all
-
-      - save_cache:
-          key: terragrunt
-          paths:
-            - bin/terragrunt
-
-  apply:
-    docker:
-      - image: hashicorp/terraform:0.11.14
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: terragrunt
-          paths:
-            - bin/terragrunt
-
-      - run:
-          name: terraform apply
-          command: |
-            /root/project/bin/terragrunt apply-all --terragrunt-non-interactive
-
+version: '2.1'
+orbs:
+  terraform: circleci/terraform@3.1
 workflows:
-  version: 2
-  terraform:
+  deploy_infrastructure:
     jobs:
-      - validate
-      - plan:
+      - terraform/fmt:
+          checkout: true
+          context: terraform
+      - terraform/validate:
+          checkout: true
+          context: terraform
           requires:
-            - validate
-      - apply:
-          requires:
-            - validate
-            - plan
-          filters:
-            branches:
-              only: main
+            - terraform/fmt

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.46.0"
+  constraints = ">= 3.29.0, >= 4.6.0, >= 4.14.0"
+  hashes = [
+    "h1:WFBUQj7XI7gknCtGR+3yDhdlUiDYrONOA8HA7h2yWqY=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -11,6 +11,12 @@ resource "aws_security_group" "lb_security_group" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   # allow all outgoing traffic
   egress {

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,78 @@
+# load balancer ARN  arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb
+################################################################################
+resource "aws_security_group" "lb_security_group" {
+  name_prefix = "ecs"
+  vpc_id      = data.aws_vpc.use2.id
+
+  # allow incoming traffic
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # allow all outgoing traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [data.aws_vpc.use2.cidr_block]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb" "ecs" {
+  name_prefix     = "oc"
+  security_groups = [aws_security_group.lb_security_group.id]
+
+  load_balancer_type = "application"
+  internal           = false
+
+  subnets = data.aws_subnets.use2.ids
+
+  # idle_timeout = 60
+}
+
+
+resource "aws_lb_listener" "default_http" {
+  depends_on = [aws_lb.ecs]
+
+  load_balancer_arn = aws_lb.ecs.arn
+  protocol          = "HTTP"
+  port              = 80
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+
+resource "aws_lb_listener" "default_https" {
+  depends_on = [aws_lb.ecs]
+
+  load_balancer_arn = aws_lb.ecs.arn
+  protocol          = "HTTPS"
+  port              = 443
+  certificate_arn   = "arn:aws:acm:us-east-2:633607774026:certificate/8de9fd02-191c-485f-b952-e5ba32e90acb"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Not Found"
+      status_code  = "404"
+    }
+  }
+}

--- a/terraform/apps.tf
+++ b/terraform/apps.tf
@@ -22,10 +22,10 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_attach" {
 module "python_backend_prod" {
   source = "./python_backend"
 
-  env         = "prod"
-  vpc_id      = data.aws_vpc.use2.id
-  logs_group  = aws_cloudwatch_log_group.ecslogs.name
-  ecs_cluster_id = module.ecs.cluster_id
+  env                 = "prod"
+  vpc_id              = data.aws_vpc.use2.id
+  logs_group          = aws_cloudwatch_log_group.ecslogs.name
+  ecs_cluster_id      = module.ecs.cluster_id
   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
 }
 
@@ -48,10 +48,10 @@ resource "aws_lb_listener_rule" "python_backend_prod" {
 module "python_backend_staging" {
   source = "./python_backend"
 
-  env         = "staging"
-  vpc_id      = data.aws_vpc.use2.id
-  logs_group  = aws_cloudwatch_log_group.ecslogs.name
-  ecs_cluster_id = module.ecs.cluster_id
+  env                 = "staging"
+  vpc_id              = data.aws_vpc.use2.id
+  logs_group          = aws_cloudwatch_log_group.ecslogs.name
+  ecs_cluster_id      = module.ecs.cluster_id
   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
 }
 

--- a/terraform/apps.tf
+++ b/terraform/apps.tf
@@ -72,90 +72,120 @@ resource "aws_lb_listener_rule" "python_backend_staging" {
   }
 }
 
-# Resources API prod
-module "resources_api_prod" {
-  source = "./resources_api"
-
-  env                 = "prod"
-  vpc_id              = data.aws_vpc.use2.id
-  logs_group          = aws_cloudwatch_log_group.ecslogs.name
-  ecs_cluster_id      = module.ecs.cluster_id
-  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
-  image_tag           = "202b27d4a8be4418089469e1c79e04277268962e"
-}
-
-resource "aws_lb_listener_rule" "resources_api_prod" {
+# Redirector for shut down sites
+resource "aws_lb_listener_rule" "shutdown_sites_redirector" {
   listener_arn = aws_lb_listener.default_https.arn
 
   action {
-    type             = "forward"
-    target_group_arn = module.resources_api_prod.lb_tg_arn
-  }
+    type = "redirect"
 
-  condition {
-    host_header {
-      values = ["resources.operationcode.org"]
+    redirect {
+      host        = "www.operationcode.org"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
     }
   }
-}
-
-# Resources API staging
-module "resources_api_staging" {
-  source = "./resources_api"
-
-  env                 = "staging"
-  vpc_id              = data.aws_vpc.use2.id
-  logs_group          = aws_cloudwatch_log_group.ecslogs.name
-  ecs_cluster_id      = module.ecs.cluster_id
-  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
-  image_tag           = "fb8c59d54a5a4aed9f9cf58144eecee69f9fc58e"
-}
-
-resource "aws_lb_listener_rule" "resources_api_staging" {
-  listener_arn = aws_lb_listener.default_https.arn
-
-  action {
-    type             = "forward"
-    target_group_arn = module.resources_api_staging.lb_tg_arn
-  }
 
   condition {
     host_header {
-      values = ["resources.staging.operationcode.org", "resources-staging.operationcode.org"]
+      values = [
+        "resources.operationcode.org",
+        "resources.staging.operationcode.org",
+        "resources-staging.operationcode.org",
+        "pybot.staging.operationcode.org",
+      ]
     }
   }
 }
 
 
+# Resources API has been shut down
+# # Resources API prod
+# module "resources_api_prod" {
+#   source = "./resources_api"
+
+#   env                 = "prod"
+#   vpc_id              = data.aws_vpc.use2.id
+#   logs_group          = aws_cloudwatch_log_group.ecslogs.name
+#   ecs_cluster_id      = module.ecs.cluster_id
+#   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+#   image_tag           = "202b27d4a8be4418089469e1c79e04277268962e"
+# }
+
+# resource "aws_lb_listener_rule" "resources_api_prod" {
+#   listener_arn = aws_lb_listener.default_https.arn
+
+#   action {
+#     type             = "forward"
+#     target_group_arn = module.resources_api_prod.lb_tg_arn
+#   }
+
+#   condition {
+#     host_header {
+#       values = ["resources.operationcode.org"]
+#     }
+#   }
+# }
+
+# # Resources API staging
+# module "resources_api_staging" {
+#   source = "./resources_api"
+
+#   env                 = "staging"
+#   vpc_id              = data.aws_vpc.use2.id
+#   logs_group          = aws_cloudwatch_log_group.ecslogs.name
+#   ecs_cluster_id      = module.ecs.cluster_id
+#   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+#   image_tag           = "fb8c59d54a5a4aed9f9cf58144eecee69f9fc58e"
+# }
+
+# resource "aws_lb_listener_rule" "resources_api_staging" {
+#   listener_arn = aws_lb_listener.default_https.arn
+
+#   action {
+#     type             = "forward"
+#     target_group_arn = module.resources_api_staging.lb_tg_arn
+#   }
+
+#   condition {
+#     host_header {
+#       values = ["resources.staging.operationcode.org", "resources-staging.operationcode.org"]
+#     }
+#   }
+# }
+
+
+# note: pybot moving off to Render.com
 # Pybot staging
-module "pybot_staging" {
-  source = "./pybot"
+# module "pybot_staging" {
+#   source = "./pybot"
 
-  env                 = "staging"
-  vpc_id              = data.aws_vpc.use2.id
-  logs_group          = aws_cloudwatch_log_group.ecslogs.name
-  ecs_cluster_id      = module.ecs.cluster_id
-  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
-  image_tag           = "staging"
-}
+#   env                 = "staging"
+#   vpc_id              = data.aws_vpc.use2.id
+#   logs_group          = aws_cloudwatch_log_group.ecslogs.name
+#   ecs_cluster_id      = module.ecs.cluster_id
+#   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+#   image_tag           = "staging"
+# }
 
-resource "aws_lb_listener_rule" "pybot_staging" {
-  listener_arn = aws_lb_listener.default_https.arn
+# resource "aws_lb_listener_rule" "pybot_staging" {
+#   listener_arn = aws_lb_listener.default_https.arn
 
-  action {
-    type             = "forward"
-    target_group_arn = module.pybot_staging.lb_tg_arn
-  }
+#   action {
+#     type             = "forward"
+#     target_group_arn = module.pybot_staging.lb_tg_arn
+#   }
 
-  condition {
-    host_header {
-      values = ["pybot.staging.operationcode.org"]
-    }
-  }
+#   condition {
+#     host_header {
+#       values = ["pybot.staging.operationcode.org"]
+#     }
+#   }
 
-  condition {
-    path_pattern {
-      values = ["/slack/*", "/pybot/*", "/airtable/*"]
-    }
-  }
-}
+#   condition {
+#     path_pattern {
+#       values = ["/slack/*", "/pybot/*", "/airtable/*"]
+#     }
+#   }
+# }

--- a/terraform/apps.tf
+++ b/terraform/apps.tf
@@ -69,3 +69,55 @@ resource "aws_lb_listener_rule" "python_backend_staging" {
     }
   }
 }
+
+# Resources API prod
+module "resources_api_prod" {
+  source = "./resources_api"
+
+  env                 = "prod"
+  vpc_id              = data.aws_vpc.use2.id
+  logs_group          = aws_cloudwatch_log_group.ecslogs.name
+  ecs_cluster_id      = module.ecs.cluster_id
+  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+}
+
+resource "aws_lb_listener_rule" "resources_api_prod" {
+  listener_arn = aws_lb_listener.default_https.arn
+
+  action {
+    type             = "forward"
+    target_group_arn = module.resources_api_prod.lb_tg_arn
+  }
+
+  condition {
+    host_header {
+      values = ["resources.operationcode.org"]
+    }
+  }
+}
+
+# Resources API staging
+module "resources_api_staging" {
+  source = "./resources_api"
+
+  env                 = "staging"
+  vpc_id              = data.aws_vpc.use2.id
+  logs_group          = aws_cloudwatch_log_group.ecslogs.name
+  ecs_cluster_id      = module.ecs.cluster_id
+  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+}
+
+resource "aws_lb_listener_rule" "resources_api_staging" {
+  listener_arn = aws_lb_listener.default_https.arn
+
+  action {
+    type             = "forward"
+    target_group_arn = module.resources_api_staging.lb_tg_arn
+  }
+
+  condition {
+    host_header {
+      values = ["resources.staging.operationcode.org", "resources-staging.operationcode.org"]
+    }
+  }
+}

--- a/terraform/apps.tf
+++ b/terraform/apps.tf
@@ -27,6 +27,7 @@ module "python_backend_prod" {
   logs_group          = aws_cloudwatch_log_group.ecslogs.name
   ecs_cluster_id      = module.ecs.cluster_id
   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+  image_tag           = "master"
 }
 
 resource "aws_lb_listener_rule" "python_backend_prod" {
@@ -53,6 +54,7 @@ module "python_backend_staging" {
   logs_group          = aws_cloudwatch_log_group.ecslogs.name
   ecs_cluster_id      = module.ecs.cluster_id
   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+  image_tag           = "staging"
 }
 
 resource "aws_lb_listener_rule" "python_backend_staging" {
@@ -79,6 +81,7 @@ module "resources_api_prod" {
   logs_group          = aws_cloudwatch_log_group.ecslogs.name
   ecs_cluster_id      = module.ecs.cluster_id
   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+  image_tag           = "202b27d4a8be4418089469e1c79e04277268962e"
 }
 
 resource "aws_lb_listener_rule" "resources_api_prod" {
@@ -105,6 +108,7 @@ module "resources_api_staging" {
   logs_group          = aws_cloudwatch_log_group.ecslogs.name
   ecs_cluster_id      = module.ecs.cluster_id
   task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+  image_tag           = "fb8c59d54a5a4aed9f9cf58144eecee69f9fc58e"
 }
 
 resource "aws_lb_listener_rule" "resources_api_staging" {

--- a/terraform/apps.tf
+++ b/terraform/apps.tf
@@ -1,0 +1,71 @@
+resource "aws_cloudwatch_log_group" "ecslogs" {
+  name_prefix       = "ecs-"
+  retention_in_days = 7
+}
+
+# Secrets access stuff
+################################################################################
+data "aws_iam_role" "ecs_task_execution_role" {
+  name = "ecsTaskExecutionRole"
+}
+
+# attach aws secrets manager policy to ecs task execution role
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_attach" {
+  role       = data.aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
+}
+
+# The Apps
+################################################################################
+
+# Backend Prod
+module "python_backend_prod" {
+  source = "./python_backend"
+
+  env         = "prod"
+  vpc_id      = data.aws_vpc.use2.id
+  logs_group  = aws_cloudwatch_log_group.ecslogs.name
+  ecs_cluster_id = module.ecs.cluster_id
+  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+}
+
+resource "aws_lb_listener_rule" "python_backend_prod" {
+  listener_arn = aws_lb_listener.default_https.arn
+
+  action {
+    type             = "forward"
+    target_group_arn = module.python_backend_prod.lb_tg_arn
+  }
+
+  condition {
+    host_header {
+      values = ["backend.operationcode.org", "api.operationcode.org"]
+    }
+  }
+}
+
+# Backend Staging
+module "python_backend_staging" {
+  source = "./python_backend"
+
+  env         = "staging"
+  vpc_id      = data.aws_vpc.use2.id
+  logs_group  = aws_cloudwatch_log_group.ecslogs.name
+  ecs_cluster_id = module.ecs.cluster_id
+  task_execution_role = data.aws_iam_role.ecs_task_execution_role.arn
+}
+
+resource "aws_lb_listener_rule" "python_backend_staging" {
+  listener_arn = aws_lb_listener.default_https.arn
+
+  action {
+    type             = "forward"
+    target_group_arn = module.python_backend_staging.lb_tg_arn
+  }
+
+  condition {
+    host_header {
+      values = ["backend-staging.operationcode.org", "api.staging.operationcode.org"]
+    }
+  }
+}

--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -1,0 +1,97 @@
+
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html#ecs-optimized-ami-linux
+data "aws_ssm_parameter" "ecs_optimized_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended"
+}
+
+# https://registry.terraform.io/modules/terraform-aws-modules/autoscaling/aws/latest
+module "autoscaling" {
+  source  = "terraform-aws-modules/autoscaling/aws"
+  version = "~> 6.5"
+
+  name             = "${local.name}-spot"
+  instance_type    = "t3.small"
+  min_size         = 1
+  max_size         = 1
+  desired_capacity = 1
+  instance_market_options = {
+    market_type = "spot"
+  }
+
+  image_id                        = jsondecode(data.aws_ssm_parameter.ecs_optimized_ami.value)["image_id"]
+  user_data                       = base64encode(local.user_data)
+  ignore_desired_capacity_changes = true
+  key_name                        = "oc-ops"
+
+  create_iam_instance_profile = true
+  iam_role_name               = local.name
+  iam_role_description        = "ECS role for ${local.name}"
+  iam_role_policies = {
+    AmazonEC2ContainerServiceforEC2Role = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+    AmazonSSMManagedInstanceCore        = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  }
+
+  vpc_zone_identifier = data.aws_subnets.use2.ids
+  health_check_type   = "EC2"
+  network_interfaces = [
+    {
+      delete_on_termination       = true
+      device_index                = 0
+      associate_public_ip_address = true
+      security_groups             = [module.autoscaling_sg.security_group_id]
+    }
+  ]
+
+  # https://github.com/hashicorp/terraform-provider-aws/issues/12582
+  autoscaling_group_tags = {
+    AmazonECSManaged = true
+  }
+
+  # Required for  managed_termination_protection = "ENABLED"
+  protect_from_scale_in = false
+
+  tags = local.tags
+}
+
+# https://registry.terraform.io/modules/terraform-aws-modules/security-group/aws/latest
+module "autoscaling_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name        = local.name
+  description = "Autoscaling group security group"
+  vpc_id      = data.aws_vpc.use2.id
+
+  # Inbound admin ssh
+  ingress_with_cidr_blocks = [
+    {
+      rule = "ssh-tcp"
+      cidr_blocks = "73.37.119.155/32"
+    }
+  ]
+
+  # Inbound all high ports from the alb
+  ingress_with_source_security_group_id = [
+    {
+      source_security_group_id = aws_security_group.lb_security_group.id
+      from_port = 1024
+      to_port = 65535
+      protocol= "tcp"
+    }
+  ]
+
+  egress_rules = ["all-all"]
+
+  tags = local.tags
+}
+
+data "aws_vpc" "use2" {
+  id = "vpc-193af371"
+}
+
+data "aws_subnets" "use2" {
+  filter {
+    name   = "vpc-id"
+    values = ["vpc-193af371"]
+  }
+}

--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -12,8 +12,8 @@ module "autoscaling" {
   name             = "${local.name}-spot"
   instance_type    = "t3.small"
   min_size         = 1
-  max_size         = 3
-  desired_capacity = 2
+  max_size         = 2
+  desired_capacity = 1
   instance_market_options = {
     market_type = "spot"
   }

--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -42,6 +42,20 @@ module "autoscaling" {
     }
   ]
 
+  block_device_mappings = [
+    {
+      # Root volume
+      device_name = "/dev/xvda"
+      no_device   = 0
+      ebs = {
+        delete_on_termination = true
+        encrypted             = false
+        volume_size           = 30
+        volume_type           = "gp3"
+      }
+    }
+  ]
+
   # https://github.com/hashicorp/terraform-provider-aws/issues/12582
   autoscaling_group_tags = {
     AmazonECSManaged = true

--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -65,7 +65,7 @@ module "autoscaling_sg" {
   # Inbound admin ssh
   ingress_with_cidr_blocks = [
     {
-      rule = "ssh-tcp"
+      rule        = "ssh-tcp"
       cidr_blocks = "73.37.119.155/32"
     }
   ]
@@ -74,9 +74,9 @@ module "autoscaling_sg" {
   ingress_with_source_security_group_id = [
     {
       source_security_group_id = aws_security_group.lb_security_group.id
-      from_port = 1024
-      to_port = 65535
-      protocol= "tcp"
+      from_port                = 1024
+      to_port                  = 65535
+      protocol                 = "tcp"
     }
   ]
 

--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -12,8 +12,8 @@ module "autoscaling" {
   name             = "${local.name}-spot"
   instance_type    = "t3.small"
   min_size         = 1
-  max_size         = 1
-  desired_capacity = 1
+  max_size         = 3
+  desired_capacity = 2
   instance_market_options = {
     market_type = "spot"
   }

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -28,6 +28,7 @@ locals {
 # ECS Module
 ################################################################################
 
+# https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws/latest
 module "ecs" {
   source  = "terraform-aws-modules/ecs/aws"
   version = "~> 4.0"
@@ -58,12 +59,12 @@ module "ecs" {
   autoscaling_capacity_providers = {
     spot_instances = {
       auto_scaling_group_arn         = module.autoscaling.autoscaling_group_arn
-      managed_termination_protection = "ENABLED"
+      managed_termination_protection = "DISABLED"
 
       managed_scaling = {
         maximum_scaling_step_size = 3
         minimum_scaling_step_size = 1
-        status                    = "ENABLED"
+        status                    = "DISABLED"
         target_capacity           = 80
       }
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,83 @@
+provider "aws" {
+  region = local.region
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  region     = "us-east-2"
+  name       = "operationcode-ecs-us-east-2"
+  account_id = data.aws_caller_identity.current.account_id
+
+  user_data = <<-EOT
+    #!/bin/bash
+    cat <<'EOF' >> /etc/ecs/ecs.config
+    ECS_CLUSTER=${local.name}
+    ECS_LOGLEVEL=debug
+    ECS_ENABLE_AWSLOGS_EXECUTIONROLE_OVERRIDE=true
+    EOF
+  EOT
+
+  tags = {
+    Name       = local.name
+    Repository = "https://github.com/terraform-aws-modules/terraform-aws-ecs"
+  }
+}
+
+################################################################################
+# ECS Module
+################################################################################
+
+module "ecs" {
+  source  = "terraform-aws-modules/ecs/aws"
+  version = "~> 4.0"
+
+  cluster_name = local.name
+
+  cluster_configuration = {
+    execute_command_configuration = {
+      # logging = "OVERRIDE"
+      # log_configuration = {
+      #   # You can set a simple string and ECS will create the CloudWatch log group for you
+      #   # or you can create the resource yourself as shown here to better manage retetion, tagging, etc.
+      #   # Embedding it into the module is not trivial and therefore it is externalized
+      #   cloud_watch_log_group_name = aws_cloudwatch_log_group.this.name
+      # }
+    }
+  }
+
+  default_capacity_provider_use_fargate = false
+
+  # Capacity provider - Fargate
+  fargate_capacity_providers = {
+    FARGATE      = {}
+    FARGATE_SPOT = {}
+  }
+
+  # Capacity provider - autoscaling groups
+  autoscaling_capacity_providers = {
+    spot_instances = {
+      auto_scaling_group_arn         = module.autoscaling.autoscaling_group_arn
+      managed_termination_protection = "ENABLED"
+
+      managed_scaling = {
+        maximum_scaling_step_size = 3
+        minimum_scaling_step_size = 1
+        status                    = "ENABLED"
+        target_capacity           = 80
+      }
+
+      default_capacity_provider_strategy = {
+        weight = 60
+        base   = 20
+      }
+    }
+  }
+
+  tags = local.tags
+}
+
+
+################################################################################
+# Supporting Resources
+################################################################################

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket = "operationcode-infra-config"
+    key    = "ecs/terraform.tfstate"
+    region = "us-east-2"
+  }
+}

--- a/terraform/pybot/main.tf
+++ b/terraform/pybot/main.tf
@@ -1,0 +1,112 @@
+data "aws_secretsmanager_secret" "ecs" {
+  name = "${var.env}/pybot"
+}
+
+data "aws_secretsmanager_secret_version" "ecs-secrets" {
+  secret_id = data.aws_secretsmanager_secret.ecs.id
+}
+
+locals {
+  long_env_name = var.env == "prod" ? "production" : var.env
+
+  # CHANGEME once infra scales up
+  cpu    = var.env == "prod" ? 256 : 256
+  memory = var.env == "prod" ? 256 : 128
+  count  = var.env == "prod" ? 1 : 1
+
+
+  # Takes all of the keys from the secret manager k/v store and turns them into a map suitable for use in the container definition
+  # manage at https://us-east-2.console.aws.amazon.com/secretsmanager/listsecrets?region=us-east-2
+  secrets     = jsondecode(data.aws_secretsmanager_secret_version.ecs-secrets.secret_string)
+  secrets_env = nonsensitive(toset([for i, v in local.secrets : tomap({ "name" = upper(i), "valueFrom" = "${data.aws_secretsmanager_secret.ecs.arn}:${i}::" })]))
+}
+
+
+resource "aws_ecs_task_definition" "pybot" {
+  family             = "pybot_${var.env}"
+  execution_role_arn = var.task_execution_role
+  network_mode       = "bridge"
+  cpu                = local.cpu
+  memory             = local.memory
+
+  container_definitions = jsonencode([
+    {
+      name      = "pybot_${var.env}"
+      image     = "633607774026.dkr.ecr.us-east-2.amazonaws.com/pybot:${var.image_tag}"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 5000
+          hostPort      = 0
+          protocol      = "tcp"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = var.logs_group
+          awslogs-region        = "us-east-2"
+          awslogs-stream-prefix = "pybot_${var.env}"
+        }
+      }
+
+      secrets = local.secrets_env
+
+      mountPoints = []
+      volumesFrom = []
+  }])
+}
+
+resource "aws_ecs_service" "pybot" {
+  name            = "pybot_${var.env}"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.pybot.arn
+
+  desired_count = local.count
+
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+
+  capacity_provider_strategy {
+    base              = 20
+    capacity_provider = "spot_instances"
+    weight            = 60
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.pybot.arn
+    container_name   = "pybot_${var.env}"
+    container_port   = 5000
+  }
+}
+
+# Load balancer Target group
+resource "aws_lb_target_group" "pybot" {
+  name = "ecs-pybot-${var.env}"
+
+  port        = 5000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    path                = "/health"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  deregistration_delay = 300
+}

--- a/terraform/pybot/main.tf
+++ b/terraform/pybot/main.tf
@@ -11,7 +11,7 @@ locals {
 
   # CHANGEME once infra scales up
   cpu    = var.env == "prod" ? 256 : 256
-  memory = var.env == "prod" ? 256 : 128
+  memory = var.env == "prod" ? 512 : 256
   count  = var.env == "prod" ? 1 : 1
 
 

--- a/terraform/pybot/outputs.tf
+++ b/terraform/pybot/outputs.tf
@@ -1,0 +1,3 @@
+output "lb_tg_arn" {
+  value = aws_lb_target_group.pybot.arn
+}

--- a/terraform/pybot/variables.tf
+++ b/terraform/pybot/variables.tf
@@ -1,0 +1,31 @@
+variable "env" {
+  type        = string
+  description = "The name of the environment"
+  default     = "prod"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC"
+}
+
+variable "logs_group" {
+  type        = string
+  description = "The name of the log group"
+}
+
+variable "ecs_cluster_id" {
+  type        = string
+  description = "The ID of the ECS cluster"
+}
+
+variable "task_execution_role" {
+  type        = string
+  description = "The name of the ECS task execution role"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "The tag of the image to deploy"
+  default     = "latest"
+}

--- a/terraform/python_backend/main.tf
+++ b/terraform/python_backend/main.tf
@@ -33,7 +33,7 @@ resource "aws_ecs_task_definition" "python_backend" {
   container_definitions = jsonencode([
     {
       name      = "python_backend_${var.env}"
-      image     = "operationcode/back-end:latest"
+      image     = "operationcode/back-end:${var.image_tag}"
       essential = true
 
       portMappings = [
@@ -138,7 +138,7 @@ resource "aws_lb_target_group" "python_backend" {
   target_type = "instance"
 
   health_check {
-    path                = "/"
+    path                = "/healthz"
     interval            = 30
     timeout             = 5
     healthy_threshold   = 2

--- a/terraform/python_backend/main.tf
+++ b/terraform/python_backend/main.tf
@@ -12,7 +12,7 @@ locals {
 
   # CHANGEME once infra scales up
   cpu    = var.env == "prod" ? 256 : 256
-  memory = var.env == "prod" ? 512 : 256
+  memory = var.env == "prod" ? 1024 : 512
   count  = var.env == "prod" ? 1 : 1
 
 

--- a/terraform/python_backend/main.tf
+++ b/terraform/python_backend/main.tf
@@ -12,7 +12,7 @@ locals {
 
   # CHANGEME once infra scales up
   cpu    = var.env == "prod" ? 256 : 256
-  memory = var.env == "prod" ? 1024 : 512
+  memory = var.env == "prod" ? 512 : 384
   count  = var.env == "prod" ? 1 : 1
 
 

--- a/terraform/python_backend/main.tf
+++ b/terraform/python_backend/main.tf
@@ -1,0 +1,142 @@
+
+data "aws_secretsmanager_secret" "ecs" {
+  name = "${var.env}/python_backend"
+}
+
+data "aws_secretsmanager_secret_version" "ecs-secrets" {
+  secret_id = data.aws_secretsmanager_secret.ecs.id
+}
+
+locals {
+  long_env_name = var.env == "prod" ? "production" : var.env
+  # Takes all of the keys from the secret manager k/v store and turns them into a map suitable for use in the container definition
+  # manage at https://us-east-2.console.aws.amazon.com/secretsmanager/listsecrets?region=us-east-2
+  secrets = jsondecode(data.aws_secretsmanager_secret_version.ecs-secrets.secret_string)
+  secrets_env = nonsensitive(toset([for i,v in local.secrets: tomap({"name" = upper(i), "valueFrom" = "${data.aws_secretsmanager_secret.ecs.arn}:${i}::"})]))
+}
+
+
+resource "aws_ecs_task_definition" "python_backend" {
+  family             = "python_backend_${var.env}"
+  execution_role_arn = var.task_execution_role
+  network_mode       = "bridge"
+  cpu                = 256
+  memory             = 512
+
+  container_definitions = jsonencode([
+    {
+      name      = "python_backend_${var.env}"
+      image     = "operationcode/back-end:latest"
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 8000
+          hostPort      = 0
+          protocol      = "tcp"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = var.logs_group
+          awslogs-region        = "us-east-2"
+          awslogs-stream-prefix = "python_backend_${var.env}"
+        }
+      }
+
+
+      environment = [
+        {
+          "name" : "ENVIRONMENT",
+          "value" : "aws_${var.env}"
+        },
+        {
+          "name" : "EXTRA_HOSTS",
+          "value" : "*"
+        },
+        {
+          "name" : "RELEASE",
+          "value" : "1.0.1"
+        },
+        {
+          "name" : "SITE_ID",
+          "value" : "4"
+        },
+        {
+          "name" : "DJANGO_ENV",
+          "value" : "${local.long_env_name}"
+        },
+        {
+          "name" : "GITHUB_REPO",
+          "value" : "operationcode/back-end"
+        },
+        {
+          "name" : "HONEYCOMB_DATASET",
+          "value" : "${local.long_env_name}-traces"
+        },
+        {
+          "name" : "DB_ENGINE",
+          "value" : "django.db.backends.postgresql"
+        },
+      ]
+
+      secrets = local.secrets_env
+
+      mountPoints = []
+      volumesFrom = []
+  }])
+}
+
+resource "aws_ecs_service" "python_backend" {
+  name            = "python_backend_${var.env}"
+  cluster         = var.ecs_cluster_id
+  task_definition = aws_ecs_task_definition.python_backend.arn
+
+  desired_count = 1
+
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+
+  capacity_provider_strategy {
+    base              = 20
+    capacity_provider = "spot_instances"
+    weight            = 60
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.python_backend.arn
+    container_name   = "python_backend_${var.env}"
+    container_port   = 8000
+  }
+}
+
+# Load balancer Target group
+resource "aws_lb_target_group" "python_backend" {
+  name = "ecs-python-backend-${var.env}"
+
+  port        = 8000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    path                = "/"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  deregistration_delay = 300
+}

--- a/terraform/python_backend/outputs.tf
+++ b/terraform/python_backend/outputs.tf
@@ -1,0 +1,3 @@
+output "lb_tg_arn" {
+  value = aws_lb_target_group.python_backend.arn
+}

--- a/terraform/python_backend/variables.tf
+++ b/terraform/python_backend/variables.tf
@@ -23,3 +23,9 @@ variable "task_execution_role" {
   type        = string
   description = "The name of the ECS task execution role"
 }
+
+variable "image_tag" {
+  type        = string
+  description = "The tag of the image to deploy"
+  default     = "latest"
+}

--- a/terraform/python_backend/variables.tf
+++ b/terraform/python_backend/variables.tf
@@ -1,0 +1,25 @@
+variable "env" {
+  type        = string
+  description = "The name of the environment"
+  default     = "prod"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC"
+}
+
+variable "logs_group" {
+  type        = string
+  description = "The name of the log group"
+}
+
+variable "ecs_cluster_id" {
+  type        = string
+  description = "The ID of the ECS cluster"
+}
+
+variable "task_execution_role" {
+  type        = string
+  description = "The name of the ECS task execution role"
+}

--- a/terraform/resources_api/main.tf
+++ b/terraform/resources_api/main.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "resources_api" {
   container_definitions = jsonencode([
     {
       name      = "resources_api_${var.env}"
-      image     = "operationcode/resources-api:latest"
+      image     = "operationcode/resources-api:${var.image_tag}"
       essential = true
 
       portMappings = [

--- a/terraform/resources_api/main.tf
+++ b/terraform/resources_api/main.tf
@@ -11,7 +11,7 @@ locals {
 
   # CHANGEME once infra scales up
   cpu    = var.env == "prod" ? 256 : 256
-  memory = var.env == "prod" ? 256 : 128
+  memory = var.env == "prod" ? 512 : 256
   count  = var.env == "prod" ? 1 : 1
 
 

--- a/terraform/resources_api/outputs.tf
+++ b/terraform/resources_api/outputs.tf
@@ -1,0 +1,3 @@
+output "lb_tg_arn" {
+  value = aws_lb_target_group.resources_api.arn
+}

--- a/terraform/resources_api/variables.tf
+++ b/terraform/resources_api/variables.tf
@@ -23,3 +23,9 @@ variable "task_execution_role" {
   type        = string
   description = "The name of the ECS task execution role"
 }
+
+variable "image_tag" {
+  type        = string
+  description = "The tag of the image to deploy"
+  default     = "latest"
+}

--- a/terraform/resources_api/variables.tf
+++ b/terraform/resources_api/variables.tf
@@ -1,0 +1,25 @@
+variable "env" {
+  type        = string
+  description = "The name of the environment"
+  default     = "prod"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC"
+}
+
+variable "logs_group" {
+  type        = string
+  description = "The name of the log group"
+}
+
+variable "ecs_cluster_id" {
+  type        = string
+  description = "The ID of the ECS cluster"
+}
+
+variable "task_execution_role" {
+  type        = string
+  description = "The name of the ECS task execution role"
+}


### PR DESCRIPTION
This PR implements an ECS on EC2-Spot based infrastructure, and applies complete configurations for running back-end and resources_api on them.  

The goal is to run these apps at a tiny fraction of their current cost, since we'll be able to eliminate the EKS backplane ($75/mo), a number of EC2 instances, the Fargate-based infra for pybot, and consolidate down to a single ALB.

This also moves our secrets over to AWS secrets manager, and does a clever thing of automatically turning every secret into an environment variable in order to make that part easier to manage in the future. 

Running cluster is up here: https://us-east-2.console.aws.amazon.com/ecs/v2/clusters/operationcode-ecs-us-east-2/services?region=us-east-2#